### PR TITLE
fix: definition path resolution

### DIFF
--- a/src/nock.utils.test.ts
+++ b/src/nock.utils.test.ts
@@ -223,6 +223,33 @@ describe('nock utils', () => {
         });
       });
 
+      it('removes apikey from path with non-trivial base url', () => {
+        const definition: RecordingDefinition = {
+          scope: 'https://localhost',
+          path: '/api/v4/get/secret?text=123',
+          method: 'GET',
+          status: 200,
+        };
+
+        removeCredentials({
+          definition,
+          scheme: {
+            id: 'api-key',
+            type: SecurityType.APIKEY,
+            in: ApiKeyPlacement.PATH,
+            name: 'api_key',
+          },
+          securityValue: { id: 'api-key', apikey: 'secret' },
+          baseUrl: 'https://gitlab.com/api', //Path ends with /api
+        });
+
+        expect(definition).toEqual({
+          scope: 'https://localhost',
+          path: `/api/v4/get/${HIDDEN_CREDENTIALS_PLACEHOLDER}?text=123`,
+          method: 'GET',
+          status: 200,
+        });
+      });
       it('removes apikey from query', () => {
         const definition: RecordingDefinition = {
           scope: 'https://localhost',

--- a/src/nock.utils.ts
+++ b/src/nock.utils.ts
@@ -119,7 +119,8 @@ function removeApiKey(
   } else if (scheme.in === ApiKeyPlacement.BODY) {
     removeApiKeyInBody(definition, loadedCredential);
   } else {
-    const definitionURL = new URL(baseUrl + definition.path);
+    const baseUrlOrigin = new URL(baseUrl).origin;
+    const definitionURL = new URL(baseUrlOrigin + definition.path);
 
     if (scheme.in === ApiKeyPlacement.PATH) {
       removeApiKeyInPath(definitionURL, loadedCredential);


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR fixes problem with definition path for providers which have non-trivial baseUrl (eg. `https://gitlab.com/api`)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
