### PR TITLE
feat: Hide credentials in rawHeaders and response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Debug logging throughout the library
 - Warning about sensitive information before they're written
+- Hiding of credentials and parameters located in rawHeaders or in response.
 
 ### Fixed
 - Check for profile provider in super.json now does not expect defined profile

--- a/src/nock.utils.test.ts
+++ b/src/nock.utils.test.ts
@@ -45,6 +45,36 @@ describe('nock utils', () => {
         });
       });
 
+      it('removes apikey from raw headers', () => {
+        const definition: RecordingDefinition = {
+          scope: 'https://localhost',
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          rawHeaders: ['api_key', 'secret'],
+        };
+
+        replaceCredentialInDefinition({
+          definition,
+          scheme: {
+            id: 'api-key',
+            type: SecurityType.APIKEY,
+            in: ApiKeyPlacement.HEADER,
+            name: 'api_key',
+          },
+          baseUrl: 'https://localhost',
+          credential: 'secret',
+        });
+
+        expect(definition).toEqual({
+          scope: 'https://localhost',
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          rawHeaders: ['api_key', HIDDEN_CREDENTIALS_PLACEHOLDER],
+        });
+      });
+
       it('removes apikey from body', () => {
         const definition: RecordingDefinition = {
           scope: 'https://localhost',
@@ -162,6 +192,48 @@ describe('nock utils', () => {
           status: 200,
         });
       });
+
+      it('removes apikey from response', () => {
+        const definition: RecordingDefinition = {
+          scope: 'https://localhost',
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          body: {
+            my_api_key: 'secret',
+          },
+          response: {
+            some: 'data',
+            auth: { my_api_key: 'secret' },
+          },
+        };
+
+        replaceCredentialInDefinition({
+          definition,
+          scheme: {
+            id: 'api-key',
+            type: SecurityType.APIKEY,
+            in: ApiKeyPlacement.BODY,
+            name: 'api_key',
+          },
+          baseUrl: 'https://localhost',
+          credential: 'secret',
+        });
+
+        expect(definition).toEqual({
+          scope: 'https://localhost',
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          body: {
+            my_api_key: HIDDEN_CREDENTIALS_PLACEHOLDER,
+          },
+          response: {
+            some: 'data',
+            auth: { my_api_key: HIDDEN_CREDENTIALS_PLACEHOLDER },
+          },
+        });
+      });
     });
 
     describe('when removing basic auth credentials', () => {
@@ -197,6 +269,82 @@ describe('nock utils', () => {
           },
         });
       });
+
+      it('removes basic token from raw headers', () => {
+        const definition: RecordingDefinition = {
+          scope: 'https://localhost',
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            ['Authorization']: 'Basic secret',
+          },
+          rawHeaders: ['Authorization', 'secret'],
+        };
+
+        replaceCredentialInDefinition({
+          definition,
+          scheme: {
+            id: 'basic',
+            type: SecurityType.HTTP,
+            scheme: HttpScheme.BASIC,
+          },
+          baseUrl: 'https://localhost',
+          credential: 'secret',
+        });
+
+        expect(definition).toEqual({
+          scope: 'https://localhost',
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            ['Authorization']: `Basic ${HIDDEN_CREDENTIALS_PLACEHOLDER}`,
+          },
+          rawHeaders: ['Authorization', HIDDEN_CREDENTIALS_PLACEHOLDER],
+        });
+      });
+
+      it('removes basic token from response', () => {
+        const definition: RecordingDefinition = {
+          scope: 'https://localhost',
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            ['Authorization']: 'Basic secret',
+          },
+          response: {
+            some: 'data',
+            auth: { my_api_key: 'secret' },
+          },
+        };
+
+        replaceCredentialInDefinition({
+          definition,
+          scheme: {
+            id: 'basic',
+            type: SecurityType.HTTP,
+            scheme: HttpScheme.BASIC,
+          },
+          baseUrl: 'https://localhost',
+          credential: 'secret',
+        });
+
+        expect(definition).toEqual({
+          scope: 'https://localhost',
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            ['Authorization']: `Basic ${HIDDEN_CREDENTIALS_PLACEHOLDER}`,
+          },
+          response: {
+            some: 'data',
+            auth: { my_api_key: HIDDEN_CREDENTIALS_PLACEHOLDER },
+          },
+        });
+      });
     });
 
     describe('when removing bearer token', () => {
@@ -229,6 +377,82 @@ describe('nock utils', () => {
           status: 200,
           reqheaders: {
             ['Authorization']: `Bearer ${HIDDEN_CREDENTIALS_PLACEHOLDER}`,
+          },
+        });
+      });
+
+      it('removes bearer token from raw headers', () => {
+        const definition: RecordingDefinition = {
+          scope: 'https://localhost',
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            ['Authorization']: 'Bearer secret',
+          },
+          rawHeaders: ['Authorization', 'secret'],
+        };
+
+        replaceCredentialInDefinition({
+          definition,
+          scheme: {
+            id: 'bearer',
+            type: SecurityType.HTTP,
+            scheme: HttpScheme.BEARER,
+          },
+          baseUrl: 'https://localhost',
+          credential: 'secret',
+        });
+
+        expect(definition).toEqual({
+          scope: 'https://localhost',
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            ['Authorization']: `Bearer ${HIDDEN_CREDENTIALS_PLACEHOLDER}`,
+          },
+          rawHeaders: ['Authorization', HIDDEN_CREDENTIALS_PLACEHOLDER],
+        });
+      });
+
+      it('removes bearer token from response', () => {
+        const definition: RecordingDefinition = {
+          scope: 'https://localhost',
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            ['Authorization']: 'Bearer secret',
+          },
+          response: {
+            some: 'data',
+            auth: { my_api_key: 'secret' },
+          },
+        };
+
+        replaceCredentialInDefinition({
+          definition,
+          scheme: {
+            id: 'bearer',
+            type: SecurityType.HTTP,
+            scheme: HttpScheme.BEARER,
+          },
+          baseUrl: 'https://localhost',
+          credential: 'secret',
+        });
+
+        expect(definition).toEqual({
+          scope: 'https://localhost',
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            ['Authorization']: `Bearer ${HIDDEN_CREDENTIALS_PLACEHOLDER}`,
+          },
+          response: {
+            some: 'data',
+            auth: { my_api_key: HIDDEN_CREDENTIALS_PLACEHOLDER },
           },
         });
       });
@@ -393,6 +617,62 @@ describe('nock utils', () => {
           path: `/get?text=123`,
           method: 'GET',
           status: 200,
+        });
+      });
+
+      it('removes parameter from raw headers', () => {
+        const parameterValue = 'integration-parameter';
+        const definition: RecordingDefinition = {
+          scope: baseUrl,
+          path: `/get?text=123`,
+          method: 'GET',
+          status: 200,
+          rawHeaders: ['Authorization', parameterValue],
+        };
+
+        replaceParameterInDefinition({
+          definition,
+          baseUrl,
+          credential: parameterValue,
+        });
+
+        expect(definition).toEqual({
+          scope: baseUrl,
+          path: `/get?text=123`,
+          method: 'GET',
+          status: 200,
+          rawHeaders: ['Authorization', HIDDEN_PARAMETERS_PLACEHOLDER],
+        });
+      });
+
+      it('removes parameter from response', () => {
+        const parameterValue = 'integration-parameter';
+        const definition: RecordingDefinition = {
+          scope: baseUrl,
+          path: `/get?text=123`,
+          method: 'GET',
+          status: 200,
+          response: {
+            some: 'data',
+            auth: { my_api_key: parameterValue },
+          },
+        };
+
+        replaceParameterInDefinition({
+          definition,
+          baseUrl,
+          credential: parameterValue,
+        });
+
+        expect(definition).toEqual({
+          scope: baseUrl,
+          path: `/get?text=123`,
+          method: 'GET',
+          status: 200,
+          response: {
+            some: 'data',
+            auth: { my_api_key: HIDDEN_PARAMETERS_PLACEHOLDER },
+          },
         });
       });
     });

--- a/src/superface-test.interfaces.ts
+++ b/src/superface-test.interfaces.ts
@@ -6,10 +6,7 @@ import {
   UseCase,
 } from '@superfaceai/one-sdk';
 import { NonPrimitive } from '@superfaceai/one-sdk/dist/internal/interpreter/variables';
-import {
-  Definition as RecordingDefinition,
-  Scope as RecordingScope,
-} from 'nock/types';
+import { Definition } from 'nock/types';
 
 export interface SuperfaceTestConfigPayload {
   client?: SuperfaceClient;
@@ -39,8 +36,10 @@ export interface NockConfig {
   enableReqheadersRecording?: boolean;
 }
 
+export type RecordingDefinition = Definition & {
+  rawHeaders?: string[];
+};
 export type RecordingDefinitions = RecordingDefinition[];
-export type RecordingScopes = RecordingScope[];
 
 export type ProcessingFunction = (
   recordings: RecordingDefinitions
@@ -51,8 +50,3 @@ export interface RecordingProcessOptions {
   beforeRecordingSave?: ProcessingFunction;
   beforeRecordingLoad?: ProcessingFunction;
 }
-
-export {
-  Definition as RecordingDefinition,
-  Scope as RecordingScope,
-} from 'nock/types';

--- a/src/superface-test.ts
+++ b/src/superface-test.ts
@@ -145,12 +145,12 @@ export class SuperfaceTest {
 
   /**
    * Starts recording or loads recording fixture if exists.
-   * 
+   *
    * It will also process recording definitions before creating mocked requests
    * to match against constructed request and enable mocking them. This is needed
    * because stored recording fixture is possibly processed and contains placeholders
    * instead of original secrets.
-   * 
+   *
    * Recordings do not get processed if user specifies parameter `processRecordings` as false.
    */
   private async startRecording(


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Enhances hiding of credentials and parameters located in `rawHeaders` or in `response`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #7, resolves #10 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
