### PR TITLE
feat: Change format of placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Debug logging throughout the library
 - Warning about sensitive information before they're written
 
+### Changed
+- Format of placeholders for sensitive information in recordings
+
 ### Fixed
 - Check for profile provider in super.json now does not expect defined profile
 

--- a/src/nock.utils.test.ts
+++ b/src/nock.utils.test.ts
@@ -2,11 +2,11 @@ import { ApiKeyPlacement, HttpScheme, SecurityType } from '@superfaceai/ast';
 
 import { RecordingDefinition } from '.';
 import {
-  HIDDEN_CREDENTIALS_PLACEHOLDER,
-  HIDDEN_PARAMETERS_PLACEHOLDER,
   replaceCredentialInDefinition,
   replaceParameterInDefinition,
 } from './nock.utils';
+
+const TMP_PLACEHOLDER = 'placeholder';
 
 describe('nock utils', () => {
   describe('removeCredentials', () => {
@@ -32,6 +32,7 @@ describe('nock utils', () => {
           },
           baseUrl: 'https://localhost',
           credential: 'secret',
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
@@ -40,7 +41,7 @@ describe('nock utils', () => {
           method: 'GET',
           status: 200,
           reqheaders: {
-            ['api_key']: HIDDEN_CREDENTIALS_PLACEHOLDER,
+            ['api_key']: TMP_PLACEHOLDER,
           },
         });
       });
@@ -66,6 +67,7 @@ describe('nock utils', () => {
           },
           baseUrl: 'https://localhost',
           credential: 'secret',
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
@@ -74,7 +76,7 @@ describe('nock utils', () => {
           method: 'GET',
           status: 200,
           body: {
-            my_api_key: HIDDEN_CREDENTIALS_PLACEHOLDER,
+            my_api_key: TMP_PLACEHOLDER,
           },
         });
       });
@@ -97,11 +99,12 @@ describe('nock utils', () => {
           },
           baseUrl: 'https://localhost',
           credential: 'secret',
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
           scope: 'https://localhost',
-          path: `/get/${HIDDEN_CREDENTIALS_PLACEHOLDER}?text=123`,
+          path: `/get/${TMP_PLACEHOLDER}?text=123`,
           method: 'GET',
           status: 200,
         });
@@ -125,11 +128,12 @@ describe('nock utils', () => {
           },
           baseUrl: 'https://gitlab.com/api', //Path ends with /api
           credential: 'secret',
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
           scope: 'https://localhost',
-          path: `/api/v4/get/${HIDDEN_CREDENTIALS_PLACEHOLDER}?text=123`,
+          path: `/api/v4/get/${TMP_PLACEHOLDER}?text=123`,
           method: 'GET',
           status: 200,
         });
@@ -153,11 +157,12 @@ describe('nock utils', () => {
           },
           baseUrl: 'https://localhost',
           credential: 'secret',
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
           scope: 'https://localhost',
-          path: `/get?api_key=${HIDDEN_CREDENTIALS_PLACEHOLDER}&text=123`,
+          path: `/get?api_key=${TMP_PLACEHOLDER}&text=123`,
           method: 'GET',
           status: 200,
         });
@@ -185,6 +190,7 @@ describe('nock utils', () => {
           },
           baseUrl: 'https://localhost',
           credential: 'secret',
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
@@ -193,7 +199,7 @@ describe('nock utils', () => {
           method: 'GET',
           status: 200,
           reqheaders: {
-            ['Authorization']: `Basic ${HIDDEN_CREDENTIALS_PLACEHOLDER}`,
+            ['Authorization']: `Basic ${TMP_PLACEHOLDER}`,
           },
         });
       });
@@ -220,6 +226,7 @@ describe('nock utils', () => {
           },
           baseUrl: 'https://localhost',
           credential: 'secret',
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
@@ -228,7 +235,7 @@ describe('nock utils', () => {
           method: 'GET',
           status: 200,
           reqheaders: {
-            ['Authorization']: `Bearer ${HIDDEN_CREDENTIALS_PLACEHOLDER}`,
+            ['Authorization']: `Bearer ${TMP_PLACEHOLDER}`,
           },
         });
       });
@@ -255,6 +262,7 @@ describe('nock utils', () => {
           definition,
           baseUrl,
           credential: parameterValue,
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
@@ -284,6 +292,7 @@ describe('nock utils', () => {
           definition,
           baseUrl,
           credential: parameterValue,
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
@@ -292,7 +301,7 @@ describe('nock utils', () => {
           method: 'GET',
           status: 200,
           reqheaders: {
-            ['api_key']: HIDDEN_PARAMETERS_PLACEHOLDER,
+            ['api_key']: TMP_PLACEHOLDER,
           },
         });
       });
@@ -313,6 +322,7 @@ describe('nock utils', () => {
           definition,
           baseUrl,
           credential: parameterValue,
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
@@ -321,7 +331,7 @@ describe('nock utils', () => {
           method: 'GET',
           status: 200,
           body: {
-            my_api_key: HIDDEN_PARAMETERS_PLACEHOLDER,
+            my_api_key: TMP_PLACEHOLDER,
           },
         });
       });
@@ -339,11 +349,12 @@ describe('nock utils', () => {
           definition,
           baseUrl,
           credential: parameterValue,
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
           scope: baseUrl,
-          path: `/get/${HIDDEN_PARAMETERS_PLACEHOLDER}?text=123`,
+          path: `/get/${TMP_PLACEHOLDER}?text=123`,
           method: 'GET',
           status: 200,
         });
@@ -362,11 +373,12 @@ describe('nock utils', () => {
           definition,
           baseUrl,
           credential: parameterValue,
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
           scope: baseUrl,
-          path: `/get?api_key=${HIDDEN_PARAMETERS_PLACEHOLDER}&text=123`,
+          path: `/get?api_key=${TMP_PLACEHOLDER}&text=123`,
           method: 'GET',
           status: 200,
         });
@@ -386,10 +398,11 @@ describe('nock utils', () => {
           definition,
           baseUrl,
           credential: parameterValue,
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
-          scope: `https://api.${HIDDEN_PARAMETERS_PLACEHOLDER}.com`,
+          scope: `https://api.${TMP_PLACEHOLDER}.com`,
           path: `/get?text=123`,
           method: 'GET',
           status: 200,

--- a/src/nock.utils.test.ts
+++ b/src/nock.utils.test.ts
@@ -65,6 +65,7 @@ describe('nock utils', () => {
           },
           baseUrl: 'https://localhost',
           credential: 'secret',
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
@@ -72,7 +73,7 @@ describe('nock utils', () => {
           path: '/get?text=123',
           method: 'GET',
           status: 200,
-          rawHeaders: ['api_key', HIDDEN_CREDENTIALS_PLACEHOLDER],
+          rawHeaders: ['api_key', TMP_PLACEHOLDER],
         });
       });
 
@@ -223,6 +224,7 @@ describe('nock utils', () => {
           },
           baseUrl: 'https://localhost',
           credential: 'secret',
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
@@ -231,11 +233,11 @@ describe('nock utils', () => {
           method: 'GET',
           status: 200,
           body: {
-            my_api_key: HIDDEN_CREDENTIALS_PLACEHOLDER,
+            my_api_key: TMP_PLACEHOLDER,
           },
           response: {
             some: 'data',
-            auth: { my_api_key: HIDDEN_CREDENTIALS_PLACEHOLDER },
+            auth: { my_api_key: TMP_PLACEHOLDER },
           },
         });
       });
@@ -297,6 +299,7 @@ describe('nock utils', () => {
           },
           baseUrl: 'https://localhost',
           credential: 'secret',
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
@@ -305,9 +308,9 @@ describe('nock utils', () => {
           method: 'GET',
           status: 200,
           reqheaders: {
-            ['Authorization']: `Basic ${HIDDEN_CREDENTIALS_PLACEHOLDER}`,
+            ['Authorization']: `Basic ${TMP_PLACEHOLDER}`,
           },
-          rawHeaders: ['Authorization', HIDDEN_CREDENTIALS_PLACEHOLDER],
+          rawHeaders: ['Authorization', TMP_PLACEHOLDER],
         });
       });
 
@@ -335,6 +338,7 @@ describe('nock utils', () => {
           },
           baseUrl: 'https://localhost',
           credential: 'secret',
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
@@ -343,11 +347,11 @@ describe('nock utils', () => {
           method: 'GET',
           status: 200,
           reqheaders: {
-            ['Authorization']: `Basic ${HIDDEN_CREDENTIALS_PLACEHOLDER}`,
+            ['Authorization']: `Basic ${TMP_PLACEHOLDER}`,
           },
           response: {
             some: 'data',
-            auth: { my_api_key: HIDDEN_CREDENTIALS_PLACEHOLDER },
+            auth: { my_api_key: TMP_PLACEHOLDER },
           },
         });
       });
@@ -409,6 +413,7 @@ describe('nock utils', () => {
           },
           baseUrl: 'https://localhost',
           credential: 'secret',
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
@@ -417,9 +422,9 @@ describe('nock utils', () => {
           method: 'GET',
           status: 200,
           reqheaders: {
-            ['Authorization']: `Bearer ${HIDDEN_CREDENTIALS_PLACEHOLDER}`,
+            ['Authorization']: `Bearer ${TMP_PLACEHOLDER}`,
           },
-          rawHeaders: ['Authorization', HIDDEN_CREDENTIALS_PLACEHOLDER],
+          rawHeaders: ['Authorization', TMP_PLACEHOLDER],
         });
       });
 
@@ -447,6 +452,7 @@ describe('nock utils', () => {
           },
           baseUrl: 'https://localhost',
           credential: 'secret',
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
@@ -455,11 +461,11 @@ describe('nock utils', () => {
           method: 'GET',
           status: 200,
           reqheaders: {
-            ['Authorization']: `Bearer ${HIDDEN_CREDENTIALS_PLACEHOLDER}`,
+            ['Authorization']: `Bearer ${TMP_PLACEHOLDER}`,
           },
           response: {
             some: 'data',
-            auth: { my_api_key: HIDDEN_CREDENTIALS_PLACEHOLDER },
+            auth: { my_api_key: TMP_PLACEHOLDER },
           },
         });
       });
@@ -647,6 +653,7 @@ describe('nock utils', () => {
           definition,
           baseUrl,
           credential: parameterValue,
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
@@ -654,7 +661,7 @@ describe('nock utils', () => {
           path: `/get?text=123`,
           method: 'GET',
           status: 200,
-          rawHeaders: ['Authorization', HIDDEN_PARAMETERS_PLACEHOLDER],
+          rawHeaders: ['Authorization', TMP_PLACEHOLDER],
         });
       });
 
@@ -675,6 +682,7 @@ describe('nock utils', () => {
           definition,
           baseUrl,
           credential: parameterValue,
+          placeholder: TMP_PLACEHOLDER,
         });
 
         expect(definition).toEqual({
@@ -684,7 +692,7 @@ describe('nock utils', () => {
           status: 200,
           response: {
             some: 'data',
-            auth: { my_api_key: HIDDEN_PARAMETERS_PLACEHOLDER },
+            auth: { my_api_key: TMP_PLACEHOLDER },
           },
         });
       });

--- a/src/nock.utils.ts
+++ b/src/nock.utils.ts
@@ -30,9 +30,9 @@ CONSIDER DISABLING SENSITIVE INFORMATION LOGGING BY APPENDING THE DEBUG ENVIRONM
 );
 
 export const HIDDEN_CREDENTIALS_PLACEHOLDER =
-  'credentials-removed-to-keep-them-secure';
+  'credentials_removed_to_keep_them_secure';
 export const HIDDEN_PARAMETERS_PLACEHOLDER =
-  'parameters-removed-to-keep-them-secure';
+  'parameters_removed_to_keep_them_secure';
 const AUTH_HEADER_NAME = 'Authorization';
 
 const defaultPlaceholder = (isParameter: boolean) =>

--- a/src/superface-test.test.ts
+++ b/src/superface-test.test.ts
@@ -20,7 +20,6 @@ import {
 import { matchWildCard } from './common/format';
 import { exists, readFileQuiet } from './common/io';
 import { writeRecordings } from './common/output-stream';
-import { HIDDEN_CREDENTIALS_PLACEHOLDER } from './nock.utils';
 import {
   getMockedSfConfig,
   getProfileMock,
@@ -29,6 +28,7 @@ import {
   SuperfaceClientMock,
 } from './superface.mock';
 import { SuperfaceTest } from './superface-test';
+import { HIDDEN_CREDENTIALS_PLACEHOLDER } from './superface-test.utils';
 
 /* eslint-disable @typescript-eslint/unbound-method */
 
@@ -272,7 +272,7 @@ describe('SuperfaceTest', () => {
           [
             {
               scope: 'https://localhost',
-              path: `/?api_key=${HIDDEN_CREDENTIALS_PLACEHOLDER}`,
+              path: `/?api_key=${HIDDEN_CREDENTIALS_PLACEHOLDER}api-key`,
               status: 200,
               response: {
                 some: 'data',


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Changes format of placeholders that are used to hide sensitive informations. Placeholder for credentials in security schemes now have format: `SECURITY_<scheme-id>` and placeholder for integration parameters now have format: `PARAMS_<parameter-name>`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes usage of testing library with more than one integration parameters.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
