### PR TITLE
feat: Change way of representing recording names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Debug logging throughout the library
 - Warning about sensitive information before they're written
+- New parameter `currentTestName` in method `run()` for hashing recording files
+- New parameter `testInstance` in constructor for pluging in instance of used test framework
+
+### Changed
+- Hash of recording is based on parameters in following priority: `currentTestName` -> `testInstance` -> `input`
 
 ### Fixed
 - Check for profile provider in super.json now does not expect defined profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Debug logging throughout the library
 - Warning about sensitive information before they're written
-- New parameter `currentTestName` in method `run()` for hashing recording files
+- New parameter `testName` in method `run()` for hashing recording files
 - New parameter `testInstance` in constructor for pluging in instance of used test framework
 
 ### Changed
-- Hash of recording is based on parameters in following priority: `currentTestName` -> `testInstance` -> `input`
+- Hash of recording is based on parameters in following priority: `testName` -> `testInstance` -> `input`
 
 ### Fixed
 - Check for profile provider in super.json now does not expect defined profile

--- a/src/generate-hash.ts
+++ b/src/generate-hash.ts
@@ -8,7 +8,7 @@ export interface IGenerator {
   hash: (param: { input: NonPrimitive; testName?: string }) => string;
 }
 
-const generate = (value: string): string => {
+export const generate = (value: string): string => {
   debugHashing('Trying to generate hash based on specified value:', value);
 
   return createHash('md5').update(value).digest('hex');

--- a/src/generate-hash.ts
+++ b/src/generate-hash.ts
@@ -1,0 +1,65 @@
+import { NonPrimitive } from '@superfaceai/one-sdk/dist/internal/interpreter/variables';
+import { createHash } from 'crypto';
+import createDebug from 'debug';
+
+const debugHashing = createDebug('superface:testing:hash');
+
+export type GenerateFunction =
+  | (() => string)
+  | ((param: { input: NonPrimitive; testName?: string }) => string);
+
+export interface IGenerator {
+  hash: (param: { input: NonPrimitive; testName?: string }) => string;
+}
+
+const generate = (value: string): string => {
+  debugHashing('Trying to generate hash based on specified value:', value);
+
+  return createHash('md5').update(value).digest('hex');
+};
+
+export class JestGenerateHash implements IGenerator {
+  constructor(private readonly testName: string) {
+    debugHashing('Returning instance of hash generator for jest test instance');
+  }
+
+  hash(param: { input: NonPrimitive; testName?: string }): string {
+    if (param.testName) {
+      return generate(param.testName);
+    }
+
+    return generate(this.testName);
+  }
+}
+
+export class MochaGenerateHash implements IGenerator {
+  constructor(private readonly testName: string) {
+    debugHashing(
+      'Returning instance of hash generator for mocha test instance'
+    );
+  }
+
+  hash(param: { input: NonPrimitive; testName?: string }): string {
+    if (param.testName) {
+      return generate(param.testName);
+    }
+
+    return generate(this.testName);
+  }
+}
+
+export class InputGenerateHash implements IGenerator {
+  constructor() {
+    debugHashing(
+      'Returning instance of fallback hash generator based on given input'
+    );
+  }
+
+  hash(param: { input: NonPrimitive; testName?: string }): string {
+    if (param.testName) {
+      return generate(param.testName);
+    }
+
+    return generate(JSON.stringify(param.input));
+  }
+}

--- a/src/generate-hash.ts
+++ b/src/generate-hash.ts
@@ -4,10 +4,6 @@ import createDebug from 'debug';
 
 const debugHashing = createDebug('superface:testing:hash');
 
-export type GenerateFunction =
-  | (() => string)
-  | ((param: { input: NonPrimitive; testName?: string }) => string);
-
 export interface IGenerator {
   hash: (param: { input: NonPrimitive; testName?: string }) => string;
 }

--- a/src/generate-hash.ts
+++ b/src/generate-hash.ts
@@ -1,11 +1,12 @@
-import { NonPrimitive } from '@superfaceai/one-sdk/dist/internal/interpreter/variables';
 import { createHash } from 'crypto';
 import createDebug from 'debug';
+
+import { HashOptions } from './superface-test.interfaces';
 
 const debugHashing = createDebug('superface:testing:hash');
 
 export interface IGenerator {
-  hash: (param: { input: NonPrimitive; testName?: string }) => string;
+  hash: (options: HashOptions) => string;
 }
 
 export const generate = (value: string): string => {
@@ -19,9 +20,9 @@ export class JestGenerateHash implements IGenerator {
     debugHashing('Returning instance of hash generator for jest test instance');
   }
 
-  hash(param: { input: NonPrimitive; testName?: string }): string {
-    if (param.testName) {
-      return generate(param.testName);
+  hash(options: HashOptions): string {
+    if (options.testName) {
+      return generate(options.testName);
     }
 
     return generate(this.testName);
@@ -35,9 +36,9 @@ export class MochaGenerateHash implements IGenerator {
     );
   }
 
-  hash(param: { input: NonPrimitive; testName?: string }): string {
-    if (param.testName) {
-      return generate(param.testName);
+  hash(options: HashOptions): string {
+    if (options.testName) {
+      return generate(options.testName);
     }
 
     return generate(this.testName);
@@ -51,11 +52,11 @@ export class InputGenerateHash implements IGenerator {
     );
   }
 
-  hash(param: { input: NonPrimitive; testName?: string }): string {
-    if (param.testName) {
-      return generate(param.testName);
+  hash({ testName, input }: HashOptions): string {
+    if (testName) {
+      return generate(testName);
     }
 
-    return generate(JSON.stringify(param.input));
+    return generate(JSON.stringify(input));
   }
 }

--- a/src/superface-test.interfaces.ts
+++ b/src/superface-test.interfaces.ts
@@ -19,6 +19,7 @@ export interface SuperfaceTestConfigPayload {
 }
 
 export type SuperfaceTestRun = SuperfaceTestConfigPayload & {
+  currentTestName?: string;
   input: NonPrimitive;
 };
 

--- a/src/superface-test.interfaces.ts
+++ b/src/superface-test.interfaces.ts
@@ -16,9 +16,13 @@ export interface SuperfaceTestConfigPayload {
   profile?: Profile | string;
   provider?: Provider | string;
   useCase?: UseCase | string;
+  testInstance?: unknown;
 }
 
-export type SuperfaceTestRun = SuperfaceTestConfigPayload & {
+export type SuperfaceTestRun = Omit<
+  SuperfaceTestConfigPayload,
+  'testInstance'
+> & {
   currentTestName?: string;
   input: NonPrimitive;
 };

--- a/src/superface-test.interfaces.ts
+++ b/src/superface-test.interfaces.ts
@@ -19,13 +19,16 @@ export interface SuperfaceTestConfigPayload {
   testInstance?: unknown;
 }
 
+export interface HashOptions {
+  input: NonPrimitive;
+  testName?: string;
+}
+
 export type SuperfaceTestRun = Omit<
   SuperfaceTestConfigPayload,
   'testInstance'
-> & {
-  currentTestName?: string;
-  input: NonPrimitive;
-};
+> &
+  HashOptions;
 
 export interface SuperfaceTestConfig {
   client?: SuperfaceClient;

--- a/src/superface-test.test.ts
+++ b/src/superface-test.test.ts
@@ -329,7 +329,7 @@ describe('SuperfaceTest', () => {
         mocked(exists).mockResolvedValue(true);
         mocked(matchWildCard).mockReturnValueOnce(true);
 
-        await superfaceTest.run({ input: {}, currentTestName: testName });
+        await superfaceTest.run({ input: {}, testName });
 
         expect(writeRecordingsSpy).toHaveBeenCalledWith(
           joinPath(
@@ -358,7 +358,7 @@ describe('SuperfaceTest', () => {
         mocked(exists).mockResolvedValue(true);
         mocked(matchWildCard).mockReturnValueOnce(true);
 
-        await superfaceTest.run({ input });
+        await superfaceTest.run({ input, testName: undefined });
 
         expect(writeRecordingsSpy).toHaveBeenCalledWith(
           joinPath(

--- a/src/superface-test.ts
+++ b/src/superface-test.ts
@@ -6,7 +6,6 @@ import {
   Result,
   SuperfaceClient,
 } from '@superfaceai/one-sdk';
-import { createHash } from 'crypto';
 import createDebug from 'debug';
 import {
   activate as activateNock,
@@ -49,6 +48,7 @@ import {
   assertsDefinitionsAreNotStrings,
   assertsPreparedConfig,
   checkSensitiveInformation,
+  generateHash,
   getProfileId,
   getSuperJson,
   isProfileProviderLocal,
@@ -91,11 +91,9 @@ export class SuperfaceTest {
         this.sfConfig.provider.configuration
       );
 
-    const hash = createHash('md5')
-      .update(JSON.stringify(testCase.input))
-      .digest('hex');
+    const hash = generateHash(testCase.currentTestName ?? testCase.input);
 
-    debug('Created hash based on input value:', hash);
+    debug('Created hash:', hash);
 
     this.setupRecordingPath(getFixtureName(this.sfConfig), hash);
 

--- a/src/superface-test.ts
+++ b/src/superface-test.ts
@@ -96,16 +96,15 @@ export class SuperfaceTest {
         this.sfConfig.provider.configuration
       );
 
-    const hash = this.generator.hash({
-      input: testCase.input,
-      testName: testCase.currentTestName,
-    });
+    // Create a hash for access to recording files
+    const { input, testName } = testCase;
+    const hash = this.generator.hash({ input, testName });
 
     debugHashing('Created hash:', hash);
 
     this.setupRecordingPath(getFixtureName(this.sfConfig), hash);
 
-    // parse env variable and check if test should be recorded
+    // Parse env variable and check if test should be recorded
     const record = matchWildCard(this.sfConfig, process.env.SUPERFACE_LIVE_API);
     const processRecordings = options?.processRecordings ?? true;
 
@@ -117,7 +116,8 @@ export class SuperfaceTest {
 
     let result: Result<unknown, PerformError>;
     try {
-      result = await this.sfConfig.useCase.perform(testCase.input, {
+      // Run perform method on specified configuration
+      result = await this.sfConfig.useCase.perform(input, {
         provider: this.sfConfig.provider,
       });
 

--- a/src/superface-test.utils.test.ts
+++ b/src/superface-test.utils.test.ts
@@ -17,6 +17,11 @@ import {
   UnexpectedError,
 } from './common/errors';
 import {
+  InputGenerateHash,
+  JestGenerateHash,
+  MochaGenerateHash,
+} from './generate-hash';
+import {
   getMockedSfConfig,
   getProfileMock,
   getProviderMock,
@@ -27,6 +32,7 @@ import {
   assertsDefinitionsAreNotStrings,
   assertsPreparedConfig,
   checkSensitiveInformation,
+  getGenerator,
   getProfileId,
   getProviderName,
   getSuperJson,
@@ -359,6 +365,62 @@ describe('SuperfaceTest', () => {
       checkSensitiveInformation(definitions, schemes, values, params);
 
       expect(consoleOutput).toEqual([]);
+    });
+  });
+
+  describe('getGenerator', () => {
+    describe('when specified testInstance is jest expect instance', () => {
+      it('returns JestGenerateHash instance', () => {
+        const mockExpect = ((): void => {
+          console.log('simulating expect');
+        }) as any;
+
+        mockExpect.getState = () => ({
+          currentTestName: 'test name',
+        });
+
+        expect(getGenerator(mockExpect)).toBeInstanceOf(JestGenerateHash);
+      });
+    });
+
+    describe('when specified testInstance is mocha instance', () => {
+      describe("from mocha's hooks", () => {
+        it('returns MochaGenerateHash instance', () => {
+          const mockMocha = {
+            test: {
+              type: 'hook',
+            },
+            currentTest: {
+              fullTitle: () => 'test name',
+            },
+          };
+
+          expect(getGenerator(mockMocha)).toBeInstanceOf(MochaGenerateHash);
+        });
+      });
+
+      describe("from mocha's test", () => {
+        it('returns MochaGenerateHash instance when specified testInstance is mocha test instance', () => {
+          const mockMocha = {
+            test: {
+              type: 'test',
+              fullTitle: () => 'test name',
+            },
+          };
+
+          expect(getGenerator(mockMocha)).toBeInstanceOf(MochaGenerateHash);
+        });
+      });
+    });
+
+    describe('when specified testInstance is unknown', () => {
+      it('returns InputGenerateHash instance', () => {
+        const mockTestInstance = undefined;
+
+        expect(getGenerator(mockTestInstance)).toBeInstanceOf(
+          InputGenerateHash
+        );
+      });
     });
   });
 });

--- a/src/superface-test.utils.ts
+++ b/src/superface-test.utils.ts
@@ -15,6 +15,8 @@ import {
   UnexpectedError,
   UseCase,
 } from '@superfaceai/one-sdk';
+import { NonPrimitive } from '@superfaceai/one-sdk/dist/internal/interpreter/variables';
+import { createHash } from 'crypto';
 import createDebug from 'debug';
 import { join as joinPath } from 'path';
 
@@ -349,4 +351,32 @@ export function checkSensitiveInformation(
       }
     }
   }
+}
+
+/**
+ * Tries to get jest current test name from `expect` object,
+ * otherwise it generates hash according to specified testName or input
+ */
+export function generateHash(input: NonPrimitive | string): string {
+  const hash = createHash('md5');
+
+  if (typeof input === 'string') {
+    debug('Trying to generate hash based on specified test name:', input);
+
+    hash.update(input);
+  } else {
+    try {
+      const testName = expect.getState().currentTestName;
+
+      debug('Trying to generate hash based on jest test name:', testName);
+
+      hash.update(testName);
+    } catch (error) {
+      debug('Trying to generate hash based on specified input object');
+
+      hash.update(JSON.stringify(input));
+    }
+  }
+
+  return hash.digest('hex');
 }

--- a/src/superface-test.utils.ts
+++ b/src/superface-test.utils.ts
@@ -46,7 +46,6 @@ import {
 } from './nock.utils';
 
 const debug = createDebug('superface:testing');
-// const debugHashing = createDebug('superface:testing:hash');
 
 /**
  * Asserts that entered sfConfig contains every component and
@@ -366,7 +365,7 @@ function hasProperty<K extends PropertyKey>(
   return !!obj && propKey in obj;
 }
 
-function isfunction<R extends unknown>(
+function isFunction<R extends unknown>(
   value: unknown,
   returnType?: R
 ): value is () => R {
@@ -386,10 +385,10 @@ function isfunction<R extends unknown>(
  */
 export function getGenerator(testInstance: unknown): IGenerator {
   // jest instance of `expect` contains function `getState()` which should contain `currentTestName`
-  if (testInstance && isfunction(testInstance)) {
+  if (testInstance && isFunction(testInstance)) {
     if (
       hasProperty(testInstance, 'getState') &&
-      isfunction(testInstance.getState)
+      isFunction(testInstance.getState)
     ) {
       const state = testInstance.getState();
 
@@ -414,7 +413,7 @@ export function getGenerator(testInstance: unknown): IGenerator {
         if (hasProperty(testInstance, 'currentTest')) {
           if (
             hasProperty(testInstance.currentTest, 'fullTitle') &&
-            isfunction(testInstance.currentTest.fullTitle)
+            isFunction(testInstance.currentTest.fullTitle)
           ) {
             const value = testInstance.currentTest.fullTitle();
 
@@ -429,7 +428,7 @@ export function getGenerator(testInstance: unknown): IGenerator {
       if (testInstance.test.type === 'test') {
         if (
           hasProperty(testInstance.test, 'fullTitle') &&
-          isfunction(testInstance.test.fullTitle)
+          isFunction(testInstance.test.fullTitle)
         ) {
           const value = testInstance.test.fullTitle();
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Changes recording name hashing mechanism. It is now able to receive test name in method `run()` that will be hashed if specified. If not, it tries to get current test name from jest `expect`, if that fails, it will generate hash based on specified `input`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Limitations of matching recordings based solely on input object.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
