### PR TITLE
hotfix: Update recording hash generation for jest test instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Passing jest test instance into `beforeAll()` generates hash based on `currentTestName`, not specified input
 
 ## [2.0.0] - 2022-01-17
 ### Added

--- a/src/generate-hash.ts
+++ b/src/generate-hash.ts
@@ -16,7 +16,9 @@ export const generate = (value: string): string => {
 };
 
 export class JestGenerateHash implements IGenerator {
-  constructor(private readonly payload: { currentTestName?: unknown } | string) {
+  constructor(
+    private readonly payload: { currentTestName?: unknown } | string
+  ) {
     debugHashing('Returning instance of hash generator for jest test instance');
   }
 
@@ -28,7 +30,7 @@ export class JestGenerateHash implements IGenerator {
     if (typeof this.payload === 'string') {
       return generate(this.payload);
     }
-    
+
     if (
       this.payload.currentTestName === undefined ||
       typeof this.payload.currentTestName !== 'string'

--- a/src/generate-hash.ts
+++ b/src/generate-hash.ts
@@ -16,19 +16,13 @@ export const generate = (value: string): string => {
 };
 
 export class JestGenerateHash implements IGenerator {
-  constructor(
-    private readonly payload: { currentTestName?: unknown } | string
-  ) {
+  constructor(private readonly payload: { currentTestName?: unknown }) {
     debugHashing('Returning instance of hash generator for jest test instance');
   }
 
   hash(options: HashOptions): string {
     if (options.testName) {
       return generate(options.testName);
-    }
-
-    if (typeof this.payload === 'string') {
-      return generate(this.payload);
     }
 
     if (

--- a/src/generate-hash.ts
+++ b/src/generate-hash.ts
@@ -16,7 +16,7 @@ export const generate = (value: string): string => {
 };
 
 export class JestGenerateHash implements IGenerator {
-  constructor(private readonly testName: string) {
+  constructor(private readonly payload: { currentTestName?: unknown } | string) {
     debugHashing('Returning instance of hash generator for jest test instance');
   }
 
@@ -25,7 +25,18 @@ export class JestGenerateHash implements IGenerator {
       return generate(options.testName);
     }
 
-    return generate(this.testName);
+    if (typeof this.payload === 'string') {
+      return generate(this.payload);
+    }
+    
+    if (
+      this.payload.currentTestName === undefined ||
+      typeof this.payload.currentTestName !== 'string'
+    ) {
+      return generate(JSON.stringify(options.input));
+    }
+
+    return generate(this.payload.currentTestName);
   }
 }
 

--- a/src/superface-test.test.ts
+++ b/src/superface-test.test.ts
@@ -65,10 +65,6 @@ describe('SuperfaceTest', () => {
     mocked(writeRecordings).mockReset();
   });
 
-  beforeEach(() => {
-    superfaceTest = new SuperfaceTest();
-  });
-
   describe('run', () => {
     describe('when preparing configuration', () => {
       let client: SuperfaceClient,
@@ -370,12 +366,14 @@ describe('SuperfaceTest', () => {
     });
 
     describe('when hashing recordings', () => {
-      it('writes recordings to file hashed based on test instance', async () => {
+      beforeAll(async () => {
         superfaceTest = new SuperfaceTest({
           ...(await getMockedSfConfig()),
           testInstance: expect,
         });
+      });
 
+      it('writes recordings to file hashed based on test instance', async () => {
         const expectedTestName = expect.getState().currentTestName;
         const expectedHash = generate(expectedTestName);
 
@@ -399,12 +397,7 @@ describe('SuperfaceTest', () => {
         );
       });
 
-      it('writes recordings to file hashed based on parameter currentTestName', async () => {
-        superfaceTest = new SuperfaceTest({
-          ...(await getMockedSfConfig()),
-          testInstance: expect,
-        });
-
+      it('writes recordings to file hashed based on parameter testName', async () => {
         const testName = 'my-test-name';
         const expectedHash = generate(testName);
 

--- a/src/superface-test.utils.ts
+++ b/src/superface-test.utils.ts
@@ -487,13 +487,7 @@ export function getGenerator(testInstance: unknown): IGenerator {
     ) {
       const state = testInstance.getState();
 
-      if (hasProperty(state, 'currentTestName')) {
-        const testName = state.currentTestName;
-
-        if (typeof testName === 'string') {
-          return new JestGenerateHash(testName);
-        }
-      } else {
+      if (state) {
         return new JestGenerateHash(state as { currentTestName?: unknown });
       }
     }

--- a/src/superface-test.utils.ts
+++ b/src/superface-test.utils.ts
@@ -493,6 +493,8 @@ export function getGenerator(testInstance: unknown): IGenerator {
         if (typeof testName === 'string') {
           return new JestGenerateHash(testName);
         }
+      } else {
+        return new JestGenerateHash(state as { currentTestName?: unknown });
       }
     }
   }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Updates recording hash generation in case of jest test framework, where it might not contain `currentTestName` in hook `beforeAll()`, but it does in `beforeEach()`. This is similar to mocha and therefore I pass in class for hash generation state object instead of final test name, which will be available after execution gets to tests or hooks such as `beforeEach/afterEach`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Generation of recording hash based on input, when passed in jest instance into `beforeAll` hook.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
