### PR TITLE
feat: Implement hiding credentials used with digest security scheme

### DIFF
--- a/src/nock/replace-credentials.test.ts
+++ b/src/nock/replace-credentials.test.ts
@@ -488,7 +488,7 @@ describe('replaceCredentials', () => {
             [header]: enteredCredential,
           },
         };
-  
+
         replaceCredentialInDefinition({
           definition,
           scheme: {
@@ -500,7 +500,7 @@ describe('replaceCredentials', () => {
           credential: 'Unknown',
           placeholder: TMP_PLACEHOLDER,
         });
-  
+
         expect(definition).toEqual({
           scope: BASE_URL,
           path: '/get?text=123',
@@ -511,7 +511,7 @@ describe('replaceCredentials', () => {
           },
         });
       });
-  
+
       it('replaces digest token in raw headers', () => {
         const definition: RecordingDefinition = {
           scope: BASE_URL,
@@ -523,7 +523,7 @@ describe('replaceCredentials', () => {
           },
           rawHeaders: [header, enteredCredential],
         };
-  
+
         replaceCredentialInDefinition({
           definition,
           scheme: {
@@ -535,7 +535,7 @@ describe('replaceCredentials', () => {
           credential: 'Unknown',
           placeholder: TMP_PLACEHOLDER,
         });
-  
+
         expect(definition).toEqual({
           scope: BASE_URL,
           path: '/get?text=123',
@@ -564,7 +564,7 @@ describe('replaceCredentials', () => {
             [header]: enteredCredential,
           },
         };
-  
+
         replaceCredentialInDefinition({
           definition,
           scheme: {
@@ -576,7 +576,7 @@ describe('replaceCredentials', () => {
           credential: 'Unknown',
           placeholder: TMP_PLACEHOLDER,
         });
-  
+
         expect(definition).toEqual({
           scope: BASE_URL,
           path: '/get?text=123',
@@ -587,7 +587,7 @@ describe('replaceCredentials', () => {
           },
         });
       });
-  
+
       it('replaces digest token in raw headers', () => {
         const definition: RecordingDefinition = {
           scope: BASE_URL,
@@ -599,7 +599,7 @@ describe('replaceCredentials', () => {
           },
           rawHeaders: [header, enteredCredential],
         };
-  
+
         replaceCredentialInDefinition({
           definition,
           scheme: {
@@ -611,7 +611,7 @@ describe('replaceCredentials', () => {
           credential: 'Unknown',
           placeholder: TMP_PLACEHOLDER,
         });
-  
+
         expect(definition).toEqual({
           scope: BASE_URL,
           path: '/get?text=123',
@@ -640,7 +640,7 @@ describe('replaceCredentials', () => {
             [header]: enteredCredential,
           },
         };
-  
+
         replaceCredentialInDefinition({
           definition,
           scheme: {
@@ -653,7 +653,7 @@ describe('replaceCredentials', () => {
           credential: 'Unknown',
           placeholder: TMP_PLACEHOLDER,
         });
-  
+
         expect(definition).toEqual({
           scope: BASE_URL,
           path: '/get?text=123',
@@ -664,7 +664,7 @@ describe('replaceCredentials', () => {
           },
         });
       });
-  
+
       it('replaces digest token in raw headers', () => {
         const definition: RecordingDefinition = {
           scope: BASE_URL,
@@ -676,7 +676,7 @@ describe('replaceCredentials', () => {
           },
           rawHeaders: [header, enteredCredential],
         };
-  
+
         replaceCredentialInDefinition({
           definition,
           scheme: {
@@ -689,7 +689,7 @@ describe('replaceCredentials', () => {
           credential: 'Unknown',
           placeholder: TMP_PLACEHOLDER,
         });
-  
+
         expect(definition).toEqual({
           scope: BASE_URL,
           path: '/get?text=123',
@@ -706,7 +706,7 @@ describe('replaceCredentials', () => {
     describe('in custom authorization header', () => {
       beforeAll(() => {
         header = 'Custom-Authorization-Header';
-      })
+      });
 
       it('replaces digest token', () => {
         const definition: RecordingDefinition = {
@@ -718,7 +718,7 @@ describe('replaceCredentials', () => {
             [header]: enteredCredential,
           },
         };
-  
+
         replaceCredentialInDefinition({
           definition,
           scheme: {
@@ -731,7 +731,7 @@ describe('replaceCredentials', () => {
           credential: 'Unknown',
           placeholder: TMP_PLACEHOLDER,
         });
-  
+
         expect(definition).toEqual({
           scope: BASE_URL,
           path: '/get?text=123',
@@ -742,7 +742,7 @@ describe('replaceCredentials', () => {
           },
         });
       });
-  
+
       it('replaces digest token in raw headers', () => {
         const definition: RecordingDefinition = {
           scope: BASE_URL,
@@ -754,7 +754,7 @@ describe('replaceCredentials', () => {
           },
           rawHeaders: [header, enteredCredential],
         };
-  
+
         replaceCredentialInDefinition({
           definition,
           scheme: {
@@ -767,7 +767,7 @@ describe('replaceCredentials', () => {
           credential: 'Unknown',
           placeholder: TMP_PLACEHOLDER,
         });
-  
+
         expect(definition).toEqual({
           scope: BASE_URL,
           path: '/get?text=123',

--- a/src/nock/replace-credentials.test.ts
+++ b/src/nock/replace-credentials.test.ts
@@ -468,6 +468,320 @@ describe('replaceCredentials', () => {
     });
   });
 
+  describe('when replacing digest token', () => {
+    const enteredCredential = 'Digest secret';
+    const expectedValue = `Digest ${TMP_PLACEHOLDER}`;
+    let header: string;
+
+    describe('in Authorization header', () => {
+      beforeAll(() => {
+        header = 'Authorization';
+      });
+
+      it('replaces digest token', () => {
+        const definition: RecordingDefinition = {
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: enteredCredential,
+          },
+        };
+  
+        replaceCredentialInDefinition({
+          definition,
+          scheme: {
+            id: 'digest',
+            type: SecurityType.HTTP,
+            scheme: HttpScheme.DIGEST,
+          },
+          baseUrl: BASE_URL,
+          credential: 'Unknown',
+          placeholder: TMP_PLACEHOLDER,
+        });
+  
+        expect(definition).toEqual({
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: expectedValue,
+          },
+        });
+      });
+  
+      it('replaces digest token in raw headers', () => {
+        const definition: RecordingDefinition = {
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: enteredCredential,
+          },
+          rawHeaders: [header, enteredCredential],
+        };
+  
+        replaceCredentialInDefinition({
+          definition,
+          scheme: {
+            id: 'digest',
+            type: SecurityType.HTTP,
+            scheme: HttpScheme.DIGEST,
+          },
+          baseUrl: BASE_URL,
+          credential: 'Unknown',
+          placeholder: TMP_PLACEHOLDER,
+        });
+  
+        expect(definition).toEqual({
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: expectedValue,
+          },
+          rawHeaders: [header, expectedValue],
+        });
+      });
+    });
+
+    describe('in WWW-Authenticate header', () => {
+      beforeAll(() => {
+        header = 'WWW-Authenticate';
+      });
+
+      it('replaces digest token', () => {
+        const definition: RecordingDefinition = {
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: enteredCredential,
+          },
+        };
+  
+        replaceCredentialInDefinition({
+          definition,
+          scheme: {
+            id: 'digest',
+            type: SecurityType.HTTP,
+            scheme: HttpScheme.DIGEST,
+          },
+          baseUrl: BASE_URL,
+          credential: 'Unknown',
+          placeholder: TMP_PLACEHOLDER,
+        });
+  
+        expect(definition).toEqual({
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: expectedValue,
+          },
+        });
+      });
+  
+      it('replaces digest token in raw headers', () => {
+        const definition: RecordingDefinition = {
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: enteredCredential,
+          },
+          rawHeaders: [header, enteredCredential],
+        };
+  
+        replaceCredentialInDefinition({
+          definition,
+          scheme: {
+            id: 'digest',
+            type: SecurityType.HTTP,
+            scheme: HttpScheme.DIGEST,
+          },
+          baseUrl: BASE_URL,
+          credential: 'Unknown',
+          placeholder: TMP_PLACEHOLDER,
+        });
+  
+        expect(definition).toEqual({
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: expectedValue,
+          },
+          rawHeaders: [header, expectedValue],
+        });
+      });
+    });
+
+    describe('in challenge header', () => {
+      beforeAll(() => {
+        header = 'Custom-Challenge-Header';
+      });
+
+      it('replaces digest token', () => {
+        const definition: RecordingDefinition = {
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: enteredCredential,
+          },
+        };
+  
+        replaceCredentialInDefinition({
+          definition,
+          scheme: {
+            id: 'digest',
+            type: SecurityType.HTTP,
+            scheme: HttpScheme.DIGEST,
+            challengeHeader: header,
+          },
+          baseUrl: BASE_URL,
+          credential: 'Unknown',
+          placeholder: TMP_PLACEHOLDER,
+        });
+  
+        expect(definition).toEqual({
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: expectedValue,
+          },
+        });
+      });
+  
+      it('replaces digest token in raw headers', () => {
+        const definition: RecordingDefinition = {
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: enteredCredential,
+          },
+          rawHeaders: [header, enteredCredential],
+        };
+  
+        replaceCredentialInDefinition({
+          definition,
+          scheme: {
+            id: 'digest',
+            type: SecurityType.HTTP,
+            scheme: HttpScheme.DIGEST,
+            challengeHeader: header,
+          },
+          baseUrl: BASE_URL,
+          credential: 'Unknown',
+          placeholder: TMP_PLACEHOLDER,
+        });
+  
+        expect(definition).toEqual({
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: expectedValue,
+          },
+          rawHeaders: [header, expectedValue],
+        });
+      });
+    });
+
+    describe('in custom authorization header', () => {
+      beforeAll(() => {
+        header = 'Custom-Authorization-Header';
+      })
+
+      it('replaces digest token', () => {
+        const definition: RecordingDefinition = {
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: enteredCredential,
+          },
+        };
+  
+        replaceCredentialInDefinition({
+          definition,
+          scheme: {
+            id: 'digest',
+            type: SecurityType.HTTP,
+            scheme: HttpScheme.DIGEST,
+            authorizationHeader: header,
+          },
+          baseUrl: BASE_URL,
+          credential: 'Unknown',
+          placeholder: TMP_PLACEHOLDER,
+        });
+  
+        expect(definition).toEqual({
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: expectedValue,
+          },
+        });
+      });
+  
+      it('replaces digest token in raw headers', () => {
+        const definition: RecordingDefinition = {
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: enteredCredential,
+          },
+          rawHeaders: [header, enteredCredential],
+        };
+  
+        replaceCredentialInDefinition({
+          definition,
+          scheme: {
+            id: 'digest',
+            type: SecurityType.HTTP,
+            scheme: HttpScheme.DIGEST,
+            authorizationHeader: header,
+          },
+          baseUrl: BASE_URL,
+          credential: 'Unknown',
+          placeholder: TMP_PLACEHOLDER,
+        });
+  
+        expect(definition).toEqual({
+          scope: BASE_URL,
+          path: '/get?text=123',
+          method: 'GET',
+          status: 200,
+          reqheaders: {
+            [header]: expectedValue,
+          },
+          rawHeaders: [header, expectedValue],
+        });
+      });
+    });
+  });
+
   describe('when sensitive information are URL encoded', () => {
     it('replaces api key in body', async () => {
       const secret = 'шеллы';

--- a/src/superface-test.utils.ts
+++ b/src/superface-test.utils.ts
@@ -2,6 +2,7 @@ import {
   isApiKeySecurityValues,
   isBasicAuthSecurityValues,
   isBearerTokenSecurityValues,
+  isDigestSecurityValues,
   NormalizedSuperJsonDocument,
   SecurityScheme,
   SecurityValues,
@@ -247,6 +248,10 @@ export function resolveCredential(securityValue: SecurityValues): string {
     }
 
     return Buffer.from(user + ':' + password).toString('base64');
+  }
+
+  if (isDigestSecurityValues(securityValue)) {
+    return 'Unknown';
   }
 
   if (isBearerTokenSecurityValues(securityValue)) {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Implements hiding of new security scheme digest and its credentials. Also resolves #27.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Possibility of digest security scheme use.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
