### PR TITLE
feat: Keep original perform error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfaceai/testing",
-  "version": "2.0.3",
+  "version": "3.0.0-beta.0",
   "description": "Testing library for Superface capabilities.",
   "main": "dist/index.js",
   "source": "src/index.ts",

--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -2,12 +2,6 @@ import { join as joinPath } from 'path';
 
 import { CompleteSuperfaceTestConfig } from '..';
 
-const ISO_DATE_REGEX =
-  /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)((-(\d{2}):(\d{2})|Z)?)/gm;
-
-export const removeTimestamp = (payload: string): string =>
-  payload.replace(ISO_DATE_REGEX, '');
-
 export function getFixtureName(sfConfig: CompleteSuperfaceTestConfig): string {
   const { profile, provider, useCase } = sfConfig;
 

--- a/src/superface-test.interfaces.ts
+++ b/src/superface-test.interfaces.ts
@@ -1,4 +1,5 @@
 import {
+  PerformError,
   Profile,
   Provider,
   Result,
@@ -41,7 +42,7 @@ export interface SuperfaceTestConfig {
 
 export type CompleteSuperfaceTestConfig = Required<SuperfaceTestConfig>;
 
-export type TestingReturn = Result<unknown, string>;
+export type TestingReturn = Result<unknown, PerformError>;
 
 export interface NockConfig {
   path?: string;

--- a/src/superface-test.test.ts
+++ b/src/superface-test.test.ts
@@ -513,7 +513,7 @@ describe('SuperfaceTest', () => {
         mocked(matchWildCard).mockReturnValueOnce(true);
 
         await expect(superfaceTest.run({ input: {} })).resolves.toEqual({
-          error: new MapASTError('error').toString(),
+          error: new MapASTError('error'),
         });
 
         expect(performSpy).toHaveBeenCalledTimes(1);

--- a/src/superface-test.ts
+++ b/src/superface-test.ts
@@ -32,11 +32,7 @@ import {
   RecordingsNotFoundError,
   UnexpectedError,
 } from './common/errors';
-import {
-  getFixtureName,
-  matchWildCard,
-  removeTimestamp,
-} from './common/format';
+import { getFixtureName, matchWildCard } from './common/format';
 import { exists, readFileQuiet } from './common/io';
 import { writeRecordings } from './common/output-stream';
 import { IGenerator } from './generate-hash';
@@ -143,7 +139,7 @@ export class SuperfaceTest {
     if (result.isErr()) {
       debug('Perform failed with error:', result.error.toString());
 
-      return err(removeTimestamp(result.error.toString()));
+      return err(result.error);
     }
 
     if (result.isOk()) {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Removes function for omitting timestamp from error and returns original `PerformError`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As we're trying to figure out a way to test continuously map with live traffic, we can't test for concrete values and therefore we don't need to worry about changing timestamp value.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
