### PR TITLE
fix: stop using deprecated security configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepush": "yarn build && yarn test && yarn lint && yarn format"
   },
   "devDependencies": {
-    "@superfaceai/one-sdk": "^1.3.0",
+    "@superfaceai/one-sdk": "^1.5.2-rc.0",
     "@types/debug": "^4.1.7",
     "@types/jest": "^27.0.1",
     "@types/rimraf": "^3.0.2",
@@ -42,7 +42,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@superfaceai/ast": "^1.1.0",
+    "@superfaceai/ast": "^1.2.0",
     "debug": "^4.3.2",
     "nock": "^13.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepush": "yarn build && yarn test && yarn lint && yarn format"
   },
   "devDependencies": {
-    "@superfaceai/one-sdk": "^1.5.2-rc.0",
+    "@superfaceai/one-sdk": "^1.5.2",
     "@types/debug": "^4.1.7",
     "@types/jest": "^27.0.1",
     "@types/rimraf": "^3.0.2",

--- a/src/common/errors.test.ts
+++ b/src/common/errors.test.ts
@@ -3,6 +3,7 @@ import {
   ComponentUndefinedError,
   InstanceMissingError,
   MapUndefinedError,
+  ProviderUndefinedError,
   RecordingPathUndefinedError,
   SuperJsonNotFoundError,
   UnexpectedError,
@@ -37,6 +38,24 @@ describe('errors', () => {
     it('returns correct format', () => {
       expect(error.toString()).toEqual(
         'MapUndefinedError: Map for profile and provider does not exist.\nUse `superface create --map --profileId profile --providerName provider` to create it.'
+      );
+    });
+  });
+
+  describe('when throwing ProviderUndefinedError', () => {
+    const error = new ProviderUndefinedError('provider');
+
+    it('throws in correct format', () => {
+      expect(() => {
+        throw error;
+      }).toThrow(
+        `Provider provider does not exist.\nUse \`superface create --provider --providerName provider\` to create it.`
+      );
+    });
+
+    it('returns correct format', () => {
+      expect(error.toString()).toEqual(
+        'ProviderUndefinedError: Provider provider does not exist.\nUse `superface create --provider --providerName provider` to create it.'
       );
     });
   });

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -24,6 +24,15 @@ export class UnexpectedError extends ErrorBase {
   }
 }
 
+export class ProviderUndefinedError extends ErrorBase {
+  constructor(provider: string) {
+    super(
+      'ProviderUndefinedError',
+      `Provider ${provider} does not exist.\nUse \`superface create --provider --providerName ${provider}\` to create it.`
+    );
+  }
+}
+
 export class MapUndefinedError extends ErrorBase {
   constructor(profile: string, provider: string) {
     super(

--- a/src/superface-test.ts
+++ b/src/superface-test.ts
@@ -181,7 +181,11 @@ export class SuperfaceTest {
     const { configuration } = this.boundProfileProvider;
     const integrationParameters = configuration.parameters ?? {};
     const securitySchemes = configuration.security;
-    const securityValues = this.sfConfig.provider.configuration.security;
+    const securityValues =
+      this.sfConfig.client.superJson.normalized?.providers[
+        this.sfConfig.provider.configuration.name
+      ].security ?? [];
+
     const baseUrl = configuration.services.getUrl();
 
     if (baseUrl === undefined) {
@@ -285,7 +289,11 @@ export class SuperfaceTest {
       assertBoundProfileProvider(this.boundProfileProvider);
 
       const { configuration } = this.boundProfileProvider;
-      const securityValues = this.sfConfig.provider.configuration.security;
+      const securityValues =
+        this.sfConfig.client.superJson.normalized?.providers[
+          this.sfConfig.provider.configuration.name
+        ].security ?? [];
+
       const securitySchemes = configuration.security;
       const integrationParameters = configuration.parameters ?? {};
 

--- a/src/superface-test.ts
+++ b/src/superface-test.ts
@@ -53,6 +53,7 @@ import {
   checkSensitiveInformation,
   getGenerator,
   getProfileId,
+  getSecurityValues,
   getSuperJson,
   isProfileProviderLocal,
   replaceCredentials,
@@ -181,10 +182,12 @@ export class SuperfaceTest {
     const { configuration } = this.boundProfileProvider;
     const integrationParameters = configuration.parameters ?? {};
     const securitySchemes = configuration.security;
-    const securityValues =
-      this.sfConfig.client.superJson.normalized?.providers[
-        this.sfConfig.provider.configuration.name
-      ].security ?? [];
+    const superJson = this.sfConfig.client?.superJson ?? (await getSuperJson());
+
+    const securityValues = getSecurityValues(
+      this.sfConfig.provider.configuration.name,
+      superJson.normalized
+    );
 
     const baseUrl = configuration.services.getUrl();
 
@@ -289,10 +292,13 @@ export class SuperfaceTest {
       assertBoundProfileProvider(this.boundProfileProvider);
 
       const { configuration } = this.boundProfileProvider;
-      const securityValues =
-        this.sfConfig.client.superJson.normalized?.providers[
-          this.sfConfig.provider.configuration.name
-        ].security ?? [];
+      const superJson =
+        this.sfConfig.client?.superJson ?? (await getSuperJson());
+
+      const securityValues = getSecurityValues(
+        this.sfConfig.provider.configuration.name,
+        superJson.normalized
+      );
 
       const securitySchemes = configuration.security;
       const integrationParameters = configuration.parameters ?? {};

--- a/src/superface-test.utils.test.ts
+++ b/src/superface-test.utils.test.ts
@@ -12,6 +12,7 @@ import {
   InstanceMissingError,
   MapUndefinedError,
   ProfileUndefinedError,
+  ProviderUndefinedError,
   SuperJsonLoadingFailedError,
   SuperJsonNotFoundError,
   UnexpectedError,
@@ -35,6 +36,7 @@ import {
   getGenerator,
   getProfileId,
   getProviderName,
+  getSecurityValues,
   getSuperJson,
   getUseCaseName,
   isProfileProviderLocal,
@@ -232,6 +234,62 @@ describe('SuperfaceTest', () => {
       expect(() => {
         isProfileProviderLocal('provider', 'profile', mockSuperJson.normalized);
       }).not.toThrow();
+    });
+  });
+
+  describe('get security values', () => {
+    it('returns security values', async () => {
+      const superJson = new SuperJson({
+        profiles: {
+          profile: {
+            file: 'path/to/profile.supr',
+            providers: {
+              provider: {
+                file: 'path/to/map.suma',
+              },
+            },
+          },
+        },
+        providers: {
+          provider: {
+            file: 'path/to/provider.json',
+            security: [{ id: 'api-key', apikey: 'secret' }],
+          },
+        },
+      });
+
+      expect(getSecurityValues('provider', superJson.normalized)).toEqual([
+        { id: 'api-key', apikey: 'secret' },
+      ]);
+    });
+
+    it('returns empty array', async () => {
+      const superJson = new SuperJson({
+        profiles: {
+          profile: {
+            file: 'path/to/profile.supr',
+            providers: {
+              provider: {
+                file: 'path/to/map.suma',
+              },
+            },
+          },
+        },
+        providers: {
+          provider: {
+            file: 'path/to/provider.json',
+          },
+        },
+      });
+
+      expect(getSecurityValues('provider', superJson.normalized)).toEqual([]);
+    });
+
+    it('throws when provider is not defined', () => {
+      const superJson = new SuperJson();
+      expect(() =>
+        getSecurityValues('provider', superJson.normalized)
+      ).toThrowError(new ProviderUndefinedError('provider'));
     });
   });
 

--- a/src/superface-test.utils.ts
+++ b/src/superface-test.utils.ts
@@ -37,6 +37,7 @@ import {
   InstanceMissingError,
   MapUndefinedError,
   ProfileUndefinedError,
+  ProviderUndefinedError,
   SuperJsonLoadingFailedError,
   SuperJsonNotFoundError,
 } from './common/errors';
@@ -150,6 +151,24 @@ export function isProfileProviderLocal(
   if (!('file' in targetedProfileProvider)) {
     throw new MapUndefinedError(profileId, providerId);
   }
+}
+
+/**
+ * Return Security values from super.json file for specified provider
+ * @param provider name of provider
+ * @param superJsonNormalized normalized super.json document
+ * @returns array of SecurityValue
+ */
+export function getSecurityValues(
+  provider: string,
+  superJsonNormalized: NormalizedSuperJsonDocument
+): SecurityValues[] {
+  const providerSettings = superJsonNormalized.providers[provider];
+  if (providerSettings === undefined) {
+    throw new ProviderUndefinedError(provider);
+  }
+
+  return providerSettings.security;
 }
 
 /**

--- a/src/superface.mock.ts
+++ b/src/superface.mock.ts
@@ -96,31 +96,32 @@ export interface SuperfaceClientOptions {
   };
 }
 
-const DEFAULT_SUPERJSON = new SuperJson({
-  profiles: {
-    profile: {
-      file: 'path/to/profile.supr',
-      providers: {
-        provider: {
-          file: 'path/to/map.suma',
+const mockSuperJson = (security?: SecurityValues[]) =>
+  new SuperJson({
+    profiles: {
+      profile: {
+        file: 'path/to/profile.supr',
+        providers: {
+          provider: {
+            file: 'path/to/map.suma',
+          },
         },
       },
     },
-  },
-  providers: {
-    provider: {
-      file: 'path/to/provider.json',
-      security: [],
+    providers: {
+      provider: {
+        file: 'path/to/provider.json',
+        security: security ?? [],
+      },
     },
-  },
-});
+  });
 
 export const SuperfaceClientMock = jest.fn<
   SuperfaceClient,
   Parameters<(options?: SuperfaceClientOptions) => SuperfaceClient>
 >((options?: SuperfaceClientOptions) => ({
   ...Object.create(SuperfaceClient.prototype),
-  superJson: options?.superJson ?? DEFAULT_SUPERJSON,
+  superJson: options?.superJson ?? mockSuperJson(),
   getProfile: getProfileMock,
   getProvider: getProviderMock,
   cacheBoundProfileProvider: jest.fn().mockReturnValue({
@@ -148,7 +149,7 @@ export const getMockedSfConfig = async (options?: {
   parameters?: Record<string, string>;
 }): Promise<CompleteSuperfaceTestConfig> => ({
   client: new SuperfaceClientMock({
-    superJson: options?.superJson ?? DEFAULT_SUPERJSON,
+    superJson: options?.superJson ?? mockSuperJson(options?.securityValues),
     configuration: {
       baseUrl: options?.baseUrl ?? 'https://base.url',
       securitySchemes: options?.securitySchemes,

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,10 +566,10 @@
     ajv "^8.8.2"
     ajv-formats "^2.1.1"
 
-"@superfaceai/one-sdk@^1.5.2-rc.0":
-  version "1.5.2-rc.0"
-  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-1.5.2-rc.0.tgz#c8fba0e5776ffd889bbdaa95d6cd617050c66d45"
-  integrity sha512-0fk3fc/8lQIjomr4zS1DBTgRPADk1qp3/W+59n4pc+sEv/OZnRsqfE7S2uy2q1MDDbCB+Stxrv4sRUJAXSRGIQ==
+"@superfaceai/one-sdk@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-1.5.2.tgz#754c2bbe3363671549308674c87ba359c9f60e9f"
+  integrity sha512-8dWrcktQBrUb3Y8M6MtbCW+0a70tbSnv7+/Oh4fKIxqdvKRTfFjJ3Bv/1LsPxLHlah0pta+cA5ZTXCBkIP6iTA==
   dependencies:
     "@superfaceai/ast" "1.2.0"
     "@superfaceai/parser" "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -558,34 +558,35 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@superfaceai/ast@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@superfaceai/ast/-/ast-1.1.0.tgz#cb87f9c980e600bd74536e14bafe7231d15c291c"
-  integrity sha512-/Bpm21XWwUElogBB8AdKkjbe4h1vExBx2xTrfE5t74FiFZUxhnLYfVcUCKNqUqsuggF/uUUAZ+5uBtmffJYm6g==
+"@superfaceai/ast@1.2.0", "@superfaceai/ast@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@superfaceai/ast/-/ast-1.2.0.tgz#f41823d550e0b0a05a8398be22a68b7b3912dde3"
+  integrity sha512-HMmdSUNzKuVgQ9g9YS/eiv3/CitSZks8eury8sAi2QbwT+n5f9SsVcmHxL2/QbkRCmlPpRqHJ6YSCqvBZ2fu1g==
   dependencies:
-    typescript-is "^0.18.3"
+    ajv "^8.8.2"
+    ajv-formats "^2.1.1"
 
-"@superfaceai/one-sdk@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-1.3.0.tgz#741ee1454877913b420a11b14b823e6262453809"
-  integrity sha512-XyztSPy33kRpoNuCq97tL1jMdT6BX1jJ2cFaz50fjwCsfX7f+zi5qx0tvpcZM2dDRm+1dS9cRC04lweIQtmRSg==
+"@superfaceai/one-sdk@^1.5.2-rc.0":
+  version "1.5.2-rc.0"
+  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-1.5.2-rc.0.tgz#c8fba0e5776ffd889bbdaa95d6cd617050c66d45"
+  integrity sha512-0fk3fc/8lQIjomr4zS1DBTgRPADk1qp3/W+59n4pc+sEv/OZnRsqfE7S2uy2q1MDDbCB+Stxrv4sRUJAXSRGIQ==
   dependencies:
-    "@superfaceai/ast" "^1.1.0"
-    "@superfaceai/parser" "^1.1.0"
+    "@superfaceai/ast" "1.2.0"
+    "@superfaceai/parser" "1.2.0"
     abort-controller "^3.0.0"
     cross-fetch "^3.1.5"
     debug "^4.3.2"
     isomorphic-form-data "^2.0.0"
     vm2 "^3.9.7"
 
-"@superfaceai/parser@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@superfaceai/parser/-/parser-1.1.0.tgz#5e268b3cbf7c1b20aced9cddbabe8dd837c3f4b6"
-  integrity sha512-onu8Omp1nv/U+nXuf5fFW3Jg31JCTNOTOecpPoGw6NzcVDociNezdpzvlrrznPI7nna1G95vdwx0FTt3YHWaqg==
+"@superfaceai/parser@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@superfaceai/parser/-/parser-1.2.0.tgz#e89e64c9ec98ff2d1e4760c1441d88d945978a1d"
+  integrity sha512-8nQ4x15F8mygKg4BcWwzqgDVTaY5BXanvCcxirL/jKLgpGUxH+808t0KmVc2Ke9o2MdiYt/2UD2hyfpwwqN9DA==
   dependencies:
-    "@superfaceai/ast" "^1.1.0"
+    "@superfaceai/ast" "^1.2.0"
     "@types/debug" "^4.1.5"
-    debug "^4.3.1"
+    debug "^4.3.3"
     typescript "^4"
 
 "@tootallnate/once@1":
@@ -903,6 +904,13 @@ agent-base@6:
   dependencies:
     debug "4"
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -911,6 +919,16 @@ ajv@^6.10.0, ajv@^6.12.4:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.8.2:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
@@ -1314,6 +1332,13 @@ debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.3:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 decimal.js@^10.2.1:
   version "10.3.1"
@@ -2876,11 +2901,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-nested-error-stacks@^2:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
-  integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
-
 nock@^13.1.3:
   version "13.1.3"
   resolved "https://registry.yarnpkg.com/nock/-/nock-13.1.3.tgz#110b005965654a8ffb798e87bad18b467bff15f9"
@@ -3224,11 +3244,6 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
-
-reflect-metadata@>=0.1.12:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
-  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
 
 regexpp@^3.1.0:
   version "3.2.0"
@@ -3629,7 +3644,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tsutils@^3.17.1, tsutils@^3.21.0:
+tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
@@ -3671,16 +3686,6 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
-
-typescript-is@^0.18.3:
-  version "0.18.3"
-  resolved "https://registry.yarnpkg.com/typescript-is/-/typescript-is-0.18.3.tgz#143ce2b348684083fc3963b95a6c2e24abd89389"
-  integrity sha512-kBgZIJt3AKrtye1H2GYf9bWu1YS0Z9AZZl4OZG4z2Ps2jPMZuycilP9RkxPLP+tPxCUjXfmaJti9TNGoz5schA==
-  dependencies:
-    nested-error-stacks "^2"
-    tsutils "^3.17.1"
-  optionalDependencies:
-    reflect-metadata ">=0.1.12"
 
 typescript@^4:
   version "4.5.5"


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
This PR removes use of deprecated security values in provider configuration. We load security values directly from super.json (using util).

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
