### PR TITLE
feat: One recording file per test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **BREAKING CHANGE:** Recording fixtures are grouped by test file or provider
-- **BREAKING CHANGE:** Recording fixtures are stored next to test file OR in `<project>/recordings/<profile>/<provider>.recording.json`
+- **BREAKING CHANGE:** Recording fixtures are stored next to test file OR in `<project-dir>/recordings/<profile>/<provider>.recording.json`
 - **BREAKING CHANGE:** Updated One-SDK to [v2.0.0](https://github.com/superfaceai/one-sdk-js/releases/tag/v2.0.0)
 - **BREAKING CHANGE:** Use `BoundProfileProvider` instead of using client and use-case to run `perform` -> Local use only
 - Move functions used for recording in `SuperfaceTest` to seperate module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- New parameter `recordingType` in method `run()` to differentiate between prepare, teardown or main test run
 - New dev and peer dependency - Superface Parser [v1.2.0](https://github.com/superfaceai/parser/releases/tag/v1.2.0)
 - New module for preparing files necessary for `perform` (SuperJson, ProfileAST, MapAST, ProviderJson)
 - New module for mocking necessary files for `perform`
@@ -28,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Function for omitting timestamp from perform error `removeTimestamp`
 
 ### Changed
+- **BREAKING CHANGE:** Recording fixtures are grouped by test file or provider
+- **BREAKING CHANGE:** Recording fixtures are stored next to test file OR in `<project>/recordings/<profile>/<provider>.recording.json`
 - **BREAKING CHANGE:** Updated One-SDK to [v2.0.0](https://github.com/superfaceai/one-sdk-js/releases/tag/v2.0.0)
 - **BREAKING CHANGE:** Use `BoundProfileProvider` instead of using client and use-case to run `perform` -> Local use only
 - Move functions used for recording in `SuperfaceTest` to seperate module

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ const superface = new SuperfaceTest(
     path: 'nock-recordings',
     fixture: 'my-recording',
     enableReqheadersRecording: true,
-    testInstance: expect
+    testInstance: expect,
   }
 );
 ```
@@ -144,7 +144,7 @@ describe('test', () => {
 });
 ```
 
-Method `run()` initializes `BoundProfileProvider` class, runs perform for given usecase and returns **result** or **error** value from perform (More about perform in [One-SDK docs](https://github.com/superfaceai/one-sdk-js#performing-the-use-case)). Since testing library don't use `SuperfaceClient` anymore, it is **limited to local use only**. 
+Method `run()` initializes `BoundProfileProvider` class, runs perform for given usecase and returns **result** or **error** value from perform (More about perform in [One-SDK docs](https://github.com/superfaceai/one-sdk-js#performing-the-use-case)). Since testing library don't use `SuperfaceClient` anymore, it is **limited to local use only**.
 
 [OneSDK 2.0](https://github.com/superfaceai/one-sdk-js/releases/tag/v2.0.0) does not contain parser anymore, so it looks for compiled files `.ast.json` next to original ones. To support this, parser was added to testing library and can be used to parse files when no AST is found.
 
@@ -215,10 +215,10 @@ superface.run(
 );
 ```
 
-To hide sensitive information that are passed in method `run()` as `input`, you can use parameter `hideInput` to point to primitive values which will get replaced in recording fixture. 
+To hide sensitive information that are passed in method `run()` as `input`, you can use parameter `hideInput` to point to primitive values which will get replaced in recording fixture.
 
 ```typescript
-const pass = 'secret'
+const pass = 'secret';
 
 superface.run(
   {
@@ -228,13 +228,13 @@ superface.run(
     input: {
       auth: {
         username: 'user',
-        password: pass
+        password: pass,
       },
     },
   },
   {
     // value found have to be one of following: string, number or boolean
-    hideInput: ['auth.value', 'auth.password']
+    hideInput: ['auth.value', 'auth.password'],
   }
 );
 ```
@@ -275,9 +275,29 @@ superface.run(
 );
 ```
 
+If you want to differentiate between runs that are used for preparation or teardown of test environment in recordings, you can use parameter `recordingsType` and recordings for that run will be grouped in recordings file as `prepare-profile/provider/useCase` or `teardown-profile/provider/useCase`:
+
+```typescript
+import { RecordingsType } from '@superfaceai/testing';
+
+superface.run(
+  {
+    profile: 'profile',
+    provider: 'provider',
+    useCase: 'useCase',
+    input: {
+      some: 'input',
+    },
+  },
+  {
+    recordingsType: RecordingsType.PREPARE,
+  }
+);
+```
+
 ## Continuous testing
 
-Testing library supports continuous testing with live provider's traffic. This means that you can run testing library in record mode without worrying that old recording of traffic gets rewritten. Testing library compares old recording with new one and determines changes. If it find changes, it will save new traffic next to old one with suffix `-new`. 
+Testing library supports continuous testing with live provider's traffic. This means that you can run testing library in record mode without worrying that old recording of traffic gets rewritten. Testing library compares old recording with new one and determines changes. If it find changes, it will save new traffic next to old one with suffix `-new`.
 
 This recording represents new traffic and you can test your capabilities with it. First time it records new traffic, it also uses it for map and therefore you can see if map works with it, but we can also setup environment variable `USE_NEW_TRAFFIC=true` to mock new traffic instead of old one when not in record mode (it looks for recording with suffix `-new` next to old one).
 
@@ -309,7 +329,7 @@ To disable collecting and also reporting these information, you can setup enviro
 You can use enviroment variable `DEBUG` to enable logging throughout testing process.
 
 - `DEBUG="superface:testing*"` will enable all logging
-- `DEBUG="superface:testing"` will enable logging of: 
+- `DEBUG="superface:testing"` will enable logging of:
   - perform results
   - start and end of recording/mocking HTTP traffic
   - start of `beforeRecordingLoad` and `beforeRecordingSave` functions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfaceai/testing",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0-beta.5",
   "description": "Testing library for Superface capabilities.",
   "main": "dist/index.js",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfaceai/testing",
-  "version": "3.0.0-rc.0",
+  "version": "3.0.0-beta.4",
   "description": "Testing library for Superface capabilities.",
   "main": "dist/index.js",
   "source": "src/index.ts",

--- a/src/common/errors.test.ts
+++ b/src/common/errors.test.ts
@@ -8,7 +8,9 @@ import {
   ProfileUndefinedError,
   ProviderJsonUndefinedError,
   RecordingPathUndefinedError,
-  RecordingsNotFoundError,
+  RecordingsFileNotFoundError,
+  RecordingsHashNotFoundError,
+  RecordingsIndexNotFoundError,
   SuperJsonNotFoundError,
   UnexpectedError,
 } from './errors';
@@ -230,20 +232,63 @@ describe('errors', () => {
     });
   });
 
-  describe('when throwing RecordingsNotFoundError', () => {
-    const error = new RecordingsNotFoundError('path/to/recording.json');
+  describe('when throwing RecordingsFileNotFoundError', () => {
+    const error = new RecordingsFileNotFoundError('path/to/recording.json');
 
     it('throws in correct format', () => {
       expect(() => {
         throw error;
       }).toThrow(
-        'Recordings could not be found for running mocked tests at "path/to/recording.json".\nYou must call the live API first to record API traffic.\nUse the environment variable SUPERFACE_LIVE_API to call the API and record traffic.\nSee https://github.com/superfaceai/testing#recording to learn more.'
+        'Recordings file could not be found for running mocked tests at "path/to/recording.json".\nYou must call the live API first to record API traffic.\nUse the environment variable SUPERFACE_LIVE_API to call the API and record traffic.\nSee https://github.com/superfaceai/testing#recording to learn more.'
       );
     });
 
     it('returns correct format', () => {
       expect(error.toString()).toEqual(
-        'RecordingsNotFoundError: Recordings could not be found for running mocked tests at "path/to/recording.json".\nYou must call the live API first to record API traffic.\nUse the environment variable SUPERFACE_LIVE_API to call the API and record traffic.\nSee https://github.com/superfaceai/testing#recording to learn more.'
+        'RecordingsFileNotFoundError: Recordings file could not be found for running mocked tests at "path/to/recording.json".\nYou must call the live API first to record API traffic.\nUse the environment variable SUPERFACE_LIVE_API to call the API and record traffic.\nSee https://github.com/superfaceai/testing#recording to learn more.'
+      );
+    });
+  });
+
+  describe('when throwing RecordingsIndexNotFoundError', () => {
+    const error = new RecordingsIndexNotFoundError(
+      'path/to/recording.json',
+      'profile/provider/test'
+    );
+
+    it('throws in correct format', () => {
+      expect(() => {
+        throw error;
+      }).toThrow(
+        'Recordings index "profile/provider/test" could not be found in recordings file at "path/to/recording.json".\nYou must call the live API first to record API traffic.\nUse the environment variable SUPERFACE_LIVE_API to call the API and record traffic.\nSee https://github.com/superfaceai/testing#recording to learn more.'
+      );
+    });
+
+    it('returns correct format', () => {
+      expect(error.toString()).toEqual(
+        'RecordingsIndexNotFoundError: Recordings index "profile/provider/test" could not be found in recordings file at "path/to/recording.json".\nYou must call the live API first to record API traffic.\nUse the environment variable SUPERFACE_LIVE_API to call the API and record traffic.\nSee https://github.com/superfaceai/testing#recording to learn more.'
+      );
+    });
+  });
+
+  describe('when throwing RecordingsHashNotFoundError', () => {
+    const error = new RecordingsHashNotFoundError(
+      'path/to/recording.json',
+      'profile/provider/test',
+      '###'
+    );
+
+    it('throws in correct format', () => {
+      expect(() => {
+        throw error;
+      }).toThrow(
+        'Recordings hash "###" under index "profile/provider/test" could not be found in recordings file at "path/to/recording.json".\nYou must call the live API first to record API traffic.\nUse the environment variable SUPERFACE_LIVE_API to call the API and record traffic.\nSee https://github.com/superfaceai/testing#recording to learn more.'
+      );
+    });
+
+    it('returns correct format', () => {
+      expect(error.toString()).toEqual(
+        'RecordingsHashNotFoundError: Recordings hash "###" under index "profile/provider/test" could not be found in recordings file at "path/to/recording.json".\nYou must call the live API first to record API traffic.\nUse the environment variable SUPERFACE_LIVE_API to call the API and record traffic.\nSee https://github.com/superfaceai/testing#recording to learn more.'
       );
     });
   });

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -111,11 +111,29 @@ export class SuperJsonLoadingFailedError extends ErrorBase {
   }
 }
 
-export class RecordingsNotFoundError extends ErrorBase {
+export class RecordingsFileNotFoundError extends ErrorBase {
   constructor(path: string) {
     super(
-      'RecordingsNotFoundError',
-      `Recordings could not be found for running mocked tests at "${path}".\nYou must call the live API first to record API traffic.\nUse the environment variable SUPERFACE_LIVE_API to call the API and record traffic.\nSee https://github.com/superfaceai/testing#recording to learn more.`
+      'RecordingsFileNotFoundError',
+      `Recordings file could not be found for running mocked tests at "${path}".\nYou must call the live API first to record API traffic.\nUse the environment variable SUPERFACE_LIVE_API to call the API and record traffic.\nSee https://github.com/superfaceai/testing#recording to learn more.`
+    );
+  }
+}
+
+export class RecordingsIndexNotFoundError extends ErrorBase {
+  constructor(path: string, index: string) {
+    super(
+      'RecordingsIndexNotFoundError',
+      `Recordings index "${index}" could not be found in recordings file at "${path}".\nYou must call the live API first to record API traffic.\nUse the environment variable SUPERFACE_LIVE_API to call the API and record traffic.\nSee https://github.com/superfaceai/testing#recording to learn more.`
+    );
+  }
+}
+
+export class RecordingsHashNotFoundError extends ErrorBase {
+  constructor(path: string, index: string, hash: string) {
+    super(
+      'RecordingsHashNotFoundError',
+      `Recordings hash "${hash}" under index "${index}" could not be found in recordings file at "${path}".\nYou must call the live API first to record API traffic.\nUse the environment variable SUPERFACE_LIVE_API to call the API and record traffic.\nSee https://github.com/superfaceai/testing#recording to learn more.`
     );
   }
 }

--- a/src/common/output-stream.ts
+++ b/src/common/output-stream.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import { dirname } from 'path';
 import { Writable } from 'stream';
 
-import { RecordingDefinition } from '..';
+import { TestRecordings } from '../nock/recording.interfaces';
 import { exists, streamEnd, streamWrite, WritingOptions } from './io';
 
 export class OutputStream {
@@ -60,7 +60,7 @@ export class OutputStream {
 
 export async function writeRecordings(
   path: string,
-  recordings: string[] | RecordingDefinition[]
+  recordings: TestRecordings
 ): Promise<void> {
   await OutputStream.writeIfAbsent(path, JSON.stringify(recordings, null, 2), {
     dirs: true,

--- a/src/generate-hash.ts
+++ b/src/generate-hash.ts
@@ -16,7 +16,7 @@ export const generate = (value: string): string => {
 };
 
 export class JestGenerateHash implements IGenerator {
-  constructor(private readonly payload: { currentTestName?: unknown }) {
+  constructor(private readonly currentTestName?: unknown) {
     debugHashing('Returning instance of hash generator for jest test instance');
   }
 
@@ -26,13 +26,13 @@ export class JestGenerateHash implements IGenerator {
     }
 
     if (
-      this.payload.currentTestName === undefined ||
-      typeof this.payload.currentTestName !== 'string'
+      this.currentTestName === undefined ||
+      typeof this.currentTestName !== 'string'
     ) {
       return generate(JSON.stringify(options.input));
     }
 
-    return generate(this.payload.currentTestName);
+    return generate(this.currentTestName);
   }
 }
 

--- a/src/generate-hash.ts
+++ b/src/generate-hash.ts
@@ -16,7 +16,7 @@ export const generate = (value: string): string => {
 };
 
 export class JestGenerateHash implements IGenerator {
-  constructor(private readonly currentTestName?: unknown) {
+  constructor(private readonly state: { currentTestName?: unknown }) {
     debugHashing('Returning instance of hash generator for jest test instance');
   }
 
@@ -26,13 +26,13 @@ export class JestGenerateHash implements IGenerator {
     }
 
     if (
-      this.currentTestName === undefined ||
-      typeof this.currentTestName !== 'string'
+      this.state.currentTestName === undefined ||
+      typeof this.state.currentTestName !== 'string'
     ) {
       return generate(JSON.stringify(options.input));
     }
 
-    return generate(this.currentTestName);
+    return generate(this.state.currentTestName);
   }
 }
 

--- a/src/nock/matcher.ts
+++ b/src/nock/matcher.ts
@@ -3,9 +3,6 @@ import createDebug from 'debug';
 import { createSchema } from 'genson-js/dist';
 import { inspect } from 'util';
 
-import { UnexpectedError } from '../common/errors';
-import { readFileQuiet } from '../common/io';
-import { writeRecordings } from '../common/output-stream';
 import {
   AnalysisResult,
   RecordingDefinition,
@@ -33,7 +30,6 @@ import {
   getResponseHeader,
   parseBody,
 } from './matcher.utils';
-import { composeRecordingPath } from './recorder';
 
 export interface MatchHeaders {
   old?: string;
@@ -408,34 +404,17 @@ export class Matcher {
 }
 
 export async function matchTraffic(
-  oldRecordingPath: string,
+  oldTraffic: RecordingDefinitions,
   newTraffic: RecordingDefinitions
 ): Promise<AnalysisResult> {
-  // recording file exist -> record and compare new traffic
-  const oldRecording = await readFileQuiet(
-    composeRecordingPath(oldRecordingPath)
-  );
-
-  if (oldRecording === undefined) {
-    throw new UnexpectedError('Reading old recording file failed');
-  }
-
-  const oldRecordingDefs = JSON.parse(oldRecording) as RecordingDefinitions;
-
   // Match new HTTP traffic to saved for breaking changes
-  const match = await Matcher.match(oldRecordingDefs, newTraffic);
+  const match = await Matcher.match(oldTraffic, newTraffic);
 
   if (match.valid) {
     // do not save new recording as there were no breaking changes found
     return { impact: MatchImpact.NONE };
   } else {
     const impact = analyzeChangeImpact(match.errors);
-
-    // Save new traffic
-    await writeRecordings(
-      composeRecordingPath(oldRecordingPath, 'new'),
-      newTraffic
-    );
 
     return { impact, errors: match.errors };
   }

--- a/src/nock/recorder.test.ts
+++ b/src/nock/recorder.test.ts
@@ -320,7 +320,8 @@ describe('Recorder', () => {
             apikey: secret,
           },
         ],
-        {}
+        {},
+        undefined
       );
     });
 

--- a/src/nock/recorder.test.ts
+++ b/src/nock/recorder.test.ts
@@ -1,0 +1,211 @@
+import { ApiKeyPlacement, SecurityType } from '@superfaceai/ast';
+import {
+  BoundProfileProvider,
+  ok,
+  ServiceSelector,
+} from '@superfaceai/one-sdk';
+import { define, disableNetConnect, recorder } from 'nock';
+import { mocked } from 'ts-jest/utils';
+
+import { BaseURLNotFoundError } from '../common/errors';
+import { mockBoundProfileProvider } from '../superface/mock/boundProfileProvider';
+import { RecordingDefinitions } from '../superface-test.interfaces';
+import * as utils from '../superface-test.utils';
+import {
+  HIDDEN_CREDENTIALS_PLACEHOLDER,
+  HIDDEN_PARAMETERS_PLACEHOLDER,
+} from '../superface-test.utils';
+import { loadRecording, startRecording } from './recorder';
+import { getRecordings } from './recorder.utils';
+import { RecordingType } from './recording.interfaces';
+
+jest.mock('nock');
+
+jest.mock('./recorder.utils', () => ({
+  ...jest.requireActual('./recorder.utils'),
+  getRecordings: jest.fn(),
+}));
+
+const recordingsConfig = {
+  recordingsPath: 'path/to/recordings.json',
+  recordingsType: RecordingType.MAIN,
+  recordingsKey: 'profile/provider/test',
+  recordingsHash: '###',
+};
+
+const prepareBoundProfileProvider = (options?: {
+  credential?: string;
+  parameter?: string;
+}): BoundProfileProvider => {
+  return mockBoundProfileProvider(ok('value'), {
+    security: options?.credential
+      ? [
+          {
+            id: 'api-key',
+            type: SecurityType.APIKEY,
+            in: ApiKeyPlacement.QUERY,
+            name: 'api_key',
+            apikey: options.credential,
+          },
+        ]
+      : undefined,
+    parameters: options?.parameter ? { param: options.parameter } : undefined,
+    services: new ServiceSelector(
+      [{ id: 'default', baseUrl: 'http://localhost' }],
+      'default'
+    ),
+  });
+};
+
+describe('Recorder', () => {
+  afterEach(() => {
+    mocked(getRecordings).mockReset();
+    mocked(define).mockReset();
+    mocked(disableNetConnect).mockReset();
+  });
+
+  describe('startRecording', () => {
+    it('starts nock recording', async () => {
+      const recorderSpy = jest.spyOn(recorder, 'rec');
+
+      await startRecording();
+
+      expect(recorderSpy).toBeCalledTimes(1);
+      expect(recorderSpy).toBeCalledWith({
+        dont_print: true,
+        output_objects: true,
+        use_separator: false,
+        enable_reqheaders_recording: false,
+      });
+    });
+  });
+
+  describe('loadRecording', () => {
+    it('throws when service does not have base Url', async () => {
+      const config = {
+        boundProfileProvider: mockBoundProfileProvider(ok('value'), {
+          services: new ServiceSelector([], 'default'),
+        }),
+        providerName: 'provider',
+      };
+
+      mocked(getRecordings).mockResolvedValue([]);
+
+      await expect(
+        async () =>
+          await loadRecording({
+            ...recordingsConfig,
+            config,
+          })
+      ).rejects.toThrowError(new BaseURLNotFoundError('provider'));
+    });
+
+    it('Replaces credentials in recordings if parameter processRecordings is specified', async () => {
+      const secret = 'secret';
+      const integrationParam = 'integration-parameter';
+
+      const config = {
+        boundProfileProvider: prepareBoundProfileProvider({
+          credential: secret,
+          parameter: integrationParam,
+        }),
+        providerName: 'provider',
+      };
+      const sampleRecordings = [
+        {
+          scope: 'https://localhost',
+          path: `/?api_key=${HIDDEN_CREDENTIALS_PLACEHOLDER}api-key`,
+          status: 200,
+          response: { auth: `${HIDDEN_PARAMETERS_PLACEHOLDER}param` },
+        },
+      ];
+
+      const replaceSpy = jest.spyOn(utils, 'replaceCredentials');
+      const nockLoadSpy = mocked(define);
+      mocked(getRecordings).mockResolvedValue(sampleRecordings);
+
+      await loadRecording({
+        ...recordingsConfig,
+        config,
+        options: {
+          processRecordings: true,
+        },
+      });
+
+      expect(replaceSpy).toBeCalledTimes(1);
+      expect(nockLoadSpy).toBeCalledTimes(1);
+      expect(nockLoadSpy).toBeCalledWith([
+        {
+          scope: 'https://localhost',
+          path: `/?api_key=${secret}`,
+          status: 200,
+          response: { auth: integrationParam },
+        },
+      ]);
+    });
+
+    it('Calls external hook beforeRecordingLoad if specified', async () => {
+      const secret = 'secret';
+      const config = {
+        boundProfileProvider: prepareBoundProfileProvider(),
+        providerName: 'provider',
+      };
+      const sampleRecordings = {
+        scope: 'https://localhost',
+        path: '/',
+        status: 200,
+        response: { auth: secret },
+      };
+
+      const beforeRecordingLoad = jest.fn(
+        (recordings: RecordingDefinitions) => {
+          recordings.forEach((_, i) => {
+            recordings[i].response = {
+              auth: 'HIDDEN',
+            };
+          });
+        }
+      );
+      const beforeRecordingLoadSpy = mocked(beforeRecordingLoad);
+      const nockLoadSpy = mocked(define);
+
+      mocked(getRecordings).mockResolvedValue([sampleRecordings]);
+
+      await loadRecording({
+        ...recordingsConfig,
+        config,
+        options: {
+          beforeRecordingLoad: beforeRecordingLoadSpy,
+        },
+      });
+
+      expect(beforeRecordingLoadSpy).toBeCalledTimes(1);
+      expect(beforeRecordingLoadSpy).toBeCalledWith([sampleRecordings]);
+      expect(nockLoadSpy).toBeCalledTimes(1);
+      expect(nockLoadSpy).toBeCalledWith([
+        {
+          ...sampleRecordings,
+          response: { auth: 'HIDDEN' },
+        },
+      ]);
+    });
+
+    it('Disables HTTP traffic', async () => {
+      const config = {
+        boundProfileProvider: prepareBoundProfileProvider(),
+        providerName: 'provider',
+      };
+
+      const disableNetConnectSpy = mocked(disableNetConnect);
+      mocked(define);
+      mocked(getRecordings).mockResolvedValue([]);
+
+      await loadRecording({
+        ...recordingsConfig,
+        config,
+      });
+
+      expect(disableNetConnectSpy).toBeCalledTimes(1);
+    });
+  });
+});

--- a/src/nock/recorder.test.ts
+++ b/src/nock/recorder.test.ts
@@ -8,6 +8,7 @@ import { define, disableNetConnect, recorder } from 'nock';
 import { mocked } from 'ts-jest/utils';
 
 import { BaseURLNotFoundError } from '../common/errors';
+import { writeRecordings } from '../common/output-stream';
 import { mockBoundProfileProvider } from '../superface/mock/boundProfileProvider';
 import { RecordingDefinitions } from '../superface-test.interfaces';
 import * as utils from '../superface-test.utils';
@@ -15,22 +16,42 @@ import {
   HIDDEN_CREDENTIALS_PLACEHOLDER,
   HIDDEN_PARAMETERS_PLACEHOLDER,
 } from '../superface-test.utils';
-import { loadRecording, startRecording } from './recorder';
-import { getRecordings } from './recorder.utils';
-import { RecordingType } from './recording.interfaces';
+import { MatchImpact } from './analyzer';
+import { matchTraffic } from './matcher';
+import { endRecording, loadRecording, startRecording } from './recorder';
+import { getRecordings, handleRecordings } from './recorder.utils';
+import { RecordingType, TestRecordings } from './recording.interfaces';
 
 jest.mock('nock');
 
 jest.mock('./recorder.utils', () => ({
   ...jest.requireActual('./recorder.utils'),
   getRecordings: jest.fn(),
+  handleRecordings: jest.fn(),
+}));
+
+jest.mock('../common/output-stream', () => ({
+  ...jest.requireActual('../common/output-stream'),
+  writeRecordings: jest.fn(),
+}));
+
+jest.mock('./matcher', () => ({
+  ...jest.requireActual('./matcher'),
+  matchTraffic: jest.fn(),
 }));
 
 const recordingsConfig = {
-  recordingsPath: 'path/to/recordings.json',
+  recordingsPath: 'path/to/recordings',
   recordingsType: RecordingType.MAIN,
   recordingsKey: 'profile/provider/test',
   recordingsHash: '###',
+};
+
+const sampleRecordings = {
+  scope: 'https://localhost',
+  path: '/',
+  status: 200,
+  response: {},
 };
 
 const prepareBoundProfileProvider = (options?: {
@@ -57,11 +78,23 @@ const prepareBoundProfileProvider = (options?: {
   });
 };
 
+const prepareFile = (recordings: RecordingDefinitions): TestRecordings => ({
+  'profile/provider/test': {
+    '###': recordings,
+  },
+});
+
 describe('Recorder', () => {
   afterEach(() => {
     mocked(getRecordings).mockReset();
+    mocked(writeRecordings).mockReset();
+    mocked(handleRecordings).mockReset();
+    mocked(matchTraffic).mockReset();
     mocked(define).mockReset();
     mocked(disableNetConnect).mockReset();
+    /* eslint-disable-next-line @typescript-eslint/unbound-method */
+    mocked(recorder.play).mockReset();
+    mockBoundProfileProvider.mockClear();
   });
 
   describe('startRecording', () => {
@@ -206,6 +239,405 @@ describe('Recorder', () => {
       });
 
       expect(disableNetConnectSpy).toBeCalledTimes(1);
+    });
+  });
+
+  describe('endRecording', () => {
+    it('calls external hook beforeRecordingSave if specified', async () => {
+      const secret = 'secret';
+      const config = {
+        boundProfileProvider: prepareBoundProfileProvider(),
+        providerName: 'provider',
+      };
+      const sampleRecordings = {
+        scope: 'https://localhost',
+        path: '/',
+        status: 200,
+        response: { auth: secret },
+      };
+
+      const beforeRecordingSave = jest.fn(
+        (recordings: RecordingDefinitions) => {
+          recordings.forEach((_, i) => {
+            recordings[i].response = {
+              auth: 'HIDDEN',
+            };
+          });
+        }
+      );
+
+      const beforeRecordingSaveSpy = mocked(beforeRecordingSave);
+      jest.spyOn(recorder, 'play').mockReturnValue([sampleRecordings]);
+
+      await endRecording({
+        ...recordingsConfig,
+        config,
+        options: {
+          beforeRecordingSave: beforeRecordingSaveSpy,
+        },
+      });
+
+      expect(beforeRecordingSaveSpy).toBeCalledTimes(1);
+      expect(beforeRecordingSaveSpy).toBeCalledWith([sampleRecordings]);
+    });
+
+    it('checks for sensitive information', async () => {
+      const secret = 'secret';
+      const config = {
+        boundProfileProvider: prepareBoundProfileProvider({
+          credential: secret,
+        }),
+        providerName: 'provider',
+      };
+      const sampleRecordings = {
+        scope: 'https://localhost',
+        path: '/',
+        status: 200,
+        response: { auth: secret },
+      };
+
+      const checkSensitiveInformationSpy = jest.spyOn(
+        utils,
+        'checkSensitiveInformation'
+      );
+
+      jest.spyOn(recorder, 'play').mockReturnValue([sampleRecordings]);
+
+      await endRecording({
+        ...recordingsConfig,
+        config,
+      });
+
+      expect(checkSensitiveInformationSpy).toBeCalledTimes(1);
+      expect(checkSensitiveInformationSpy).toBeCalledWith(
+        [sampleRecordings],
+        [
+          {
+            id: 'api-key',
+            type: SecurityType.APIKEY,
+            in: ApiKeyPlacement.QUERY,
+            name: 'api_key',
+            apikey: secret,
+          },
+        ],
+        {}
+      );
+    });
+
+    describe('when recordings file does not exists', () => {
+      describe('and when incoming recordings are empty', () => {
+        it('writes empty recordings and returns undefined', async () => {
+          const file: TestRecordings = prepareFile([]);
+          const config = {
+            boundProfileProvider: prepareBoundProfileProvider(),
+            providerName: 'provider',
+          };
+
+          const handleRecordingsSpy = mocked(
+            handleRecordings
+          ).mockResolvedValue({
+            kind: 'default',
+            file,
+          });
+          const writeRecordingsSpy = mocked(writeRecordings);
+
+          await expect(
+            endRecording({
+              ...recordingsConfig,
+              config,
+            })
+          ).resolves.toBeUndefined();
+
+          expect(handleRecordingsSpy).toBeCalledTimes(1);
+          expect(writeRecordingsSpy).toBeCalledTimes(1);
+          expect(writeRecordingsSpy).toBeCalledWith(
+            'path/to/recordings.json',
+            file
+          );
+        });
+      });
+    });
+
+    describe('when recordings file already exists', () => {
+      describe('and when storing new recordings is allowed', () => {
+        let storeNewTraffic: string | undefined;
+
+        beforeAll(() => {
+          storeNewTraffic = process.env.STORE_NEW_TRAFFIC;
+          process.env.STORE_NEW_TRAFFIC = 'true';
+        });
+
+        afterAll(() => {
+          process.env.STORE_NEW_TRAFFIC = storeNewTraffic;
+        });
+
+        afterEach(() => {
+          mocked(matchTraffic).mockReset();
+        });
+
+        describe('and when incoming recordings are empty', () => {
+          it('writes empty recordings to new file', async () => {
+            const sampleRecordings = {
+              scope: 'https://localhost',
+              path: '/',
+              status: 200,
+              response: {},
+            };
+            const file = prepareFile([]);
+            const config = {
+              boundProfileProvider: prepareBoundProfileProvider(),
+              providerName: 'provider',
+            };
+
+            const handleRecordingsSpy = mocked(
+              handleRecordings
+            ).mockResolvedValue({
+              kind: 'new',
+              file,
+              oldRecordings: [sampleRecordings],
+            });
+            const writeRecordingsSpy = mocked(writeRecordings);
+            const matchTrafficSpy = mocked(matchTraffic);
+
+            jest.spyOn(recorder, 'play').mockReturnValue([]);
+
+            await endRecording({
+              ...recordingsConfig,
+              config,
+            });
+
+            expect(matchTrafficSpy).not.toBeCalled();
+            expect(handleRecordingsSpy).toBeCalledTimes(1);
+            expect(writeRecordingsSpy).toBeCalledTimes(1);
+            expect(writeRecordingsSpy).toBeCalledWith(
+              'path/to/recordings-new.json',
+              file
+            );
+          });
+        });
+
+        describe('and when incoming recordings are not empty', () => {
+          it('write them to new file if they do not match with old ones', async () => {
+            const sampleRecordings = {
+              scope: 'https://localhost',
+              path: '/',
+              status: 200,
+              response: {},
+            };
+            const file = prepareFile([]);
+            const config = {
+              boundProfileProvider: prepareBoundProfileProvider(),
+              providerName: 'provider',
+            };
+
+            const handleRecordingsSpy = mocked(
+              handleRecordings
+            ).mockResolvedValue({
+              kind: 'new',
+              file,
+              oldRecordings: [sampleRecordings],
+            });
+            const writeRecordingsSpy = mocked(writeRecordings);
+            const matchTrafficSpy = mocked(matchTraffic).mockResolvedValue({
+              impact: MatchImpact.MAJOR,
+              errors: {
+                added: [],
+                removed: [],
+                changed: [],
+              },
+            });
+
+            jest.spyOn(recorder, 'play').mockReturnValue([sampleRecordings]);
+
+            await endRecording({
+              ...recordingsConfig,
+              config,
+            });
+
+            expect(matchTrafficSpy).toBeCalledTimes(1);
+            expect(handleRecordingsSpy).toBeCalledTimes(1);
+            expect(writeRecordingsSpy).toBeCalledTimes(1);
+            expect(writeRecordingsSpy).toBeCalledWith(
+              'path/to/recordings-new.json',
+              file
+            );
+          });
+
+          it('do not write them to new file if they match with old ones', async () => {
+            const file = prepareFile([]);
+            const config = {
+              boundProfileProvider: prepareBoundProfileProvider(),
+              providerName: 'provider',
+            };
+
+            const handleRecordingsSpy = mocked(
+              handleRecordings
+            ).mockResolvedValue({
+              kind: 'new',
+              file,
+              oldRecordings: [sampleRecordings],
+            });
+            const writeRecordingsSpy = mocked(writeRecordings);
+            const matchTrafficSpy = mocked(matchTraffic).mockResolvedValue({
+              impact: MatchImpact.NONE,
+            });
+
+            jest.spyOn(recorder, 'play').mockReturnValue([sampleRecordings]);
+
+            await endRecording({
+              ...recordingsConfig,
+              config,
+            });
+
+            expect(matchTrafficSpy).toBeCalledTimes(1);
+            expect(handleRecordingsSpy).toBeCalledTimes(1);
+            expect(writeRecordingsSpy).not.toBeCalled();
+          });
+        });
+      });
+
+      describe('and when storing new recordings is not allowed', () => {
+        let storeNewTraffic: string | undefined;
+
+        beforeAll(() => {
+          storeNewTraffic = process.env.STORE_NEW_TRAFFIC;
+          process.env.STORE_NEW_TRAFFIC = undefined;
+        });
+
+        afterAll(() => {
+          process.env.STORE_NEW_TRAFFIC = storeNewTraffic;
+        });
+
+        it('overwrites current recordings file with incoming recordings', async () => {
+          const file = prepareFile([]);
+          const config = {
+            boundProfileProvider: prepareBoundProfileProvider(),
+            providerName: 'provider',
+          };
+
+          const handleRecordingsSpy = mocked(
+            handleRecordings
+          ).mockResolvedValue({
+            kind: 'default',
+            file,
+          });
+          const writeRecordingsSpy = mocked(writeRecordings);
+          jest.spyOn(recorder, 'play').mockReturnValue([]);
+
+          await endRecording({
+            ...recordingsConfig,
+            config,
+          });
+
+          expect(handleRecordingsSpy).toBeCalledTimes(1);
+          expect(writeRecordingsSpy).toBeCalledTimes(1);
+          expect(writeRecordingsSpy).toBeCalledWith(
+            'path/to/recordings.json',
+            file
+          );
+        });
+      });
+    });
+
+    describe('when parameter processRecordings is specified', () => {
+      it('throws when provider service does not have base Url', async () => {
+        const config = {
+          boundProfileProvider: mockBoundProfileProvider(ok('value'), {
+            services: new ServiceSelector([], 'default'),
+          }),
+          providerName: 'provider',
+        };
+
+        jest.spyOn(recorder, 'play').mockReturnValue([
+          {
+            scope: 'https://localhost',
+            path: '/',
+            status: 200,
+            response: {},
+          },
+        ]);
+
+        await expect(
+          async () =>
+            await endRecording({
+              ...recordingsConfig,
+              config,
+              options: {
+                processRecordings: true,
+              },
+            })
+        ).rejects.toThrowError(new BaseURLNotFoundError('provider'));
+      });
+
+      it('replaces credentials in recordings', async () => {
+        const secret = 'secret';
+        const integrationParam = 'integration-parameter';
+
+        const config = {
+          boundProfileProvider: mockBoundProfileProvider(ok('value'), {
+            security: [
+              {
+                id: 'api-key',
+                type: SecurityType.APIKEY,
+                in: ApiKeyPlacement.QUERY,
+                name: 'api_key',
+                apikey: secret,
+              },
+            ],
+            parameters: { param: integrationParam },
+            services: new ServiceSelector(
+              [{ id: 'default', baseUrl: 'http://localhost' }],
+              'default'
+            ),
+          }),
+          providerName: 'provider',
+        };
+        const sampleRecordings = [
+          {
+            scope: 'https://localhost',
+            path: `/?api_key=${secret}`,
+            status: 200,
+            response: { auth: integrationParam },
+          },
+        ];
+
+        mocked(getRecordings).mockResolvedValue(sampleRecordings);
+        const handleRecordingsSpy = mocked(handleRecordings).mockResolvedValue({
+          kind: 'default',
+          file: prepareFile(sampleRecordings),
+        });
+        const replaceSpy = jest.spyOn(utils, 'replaceCredentials');
+        const playSpy = jest
+          .spyOn(recorder, 'play')
+          .mockReturnValue(sampleRecordings);
+
+        await endRecording({
+          ...recordingsConfig,
+          config,
+          options: {
+            processRecordings: true,
+          },
+        });
+
+        expect(playSpy).toBeCalledTimes(1);
+        expect(replaceSpy).toBeCalledTimes(1);
+        expect(handleRecordingsSpy).toBeCalledTimes(1);
+        expect(handleRecordingsSpy).toBeCalledWith({
+          recordingsFilePath: 'path/to/recordings.json',
+          newRecordingsFilePath: 'path/to/recordings-new.json',
+          recordingsIndex: 'profile/provider/test',
+          recordingsHash: '###',
+          canSaveNewTraffic: false,
+          recordings: [
+            {
+              scope: 'https://localhost',
+              path: `/?api_key=${HIDDEN_CREDENTIALS_PLACEHOLDER}api-key`,
+              status: 200,
+              response: { auth: `${HIDDEN_PARAMETERS_PLACEHOLDER}param` },
+            },
+          ],
+        });
+      });
     });
   });
 });

--- a/src/nock/recorder.test.ts
+++ b/src/nock/recorder.test.ts
@@ -31,12 +31,10 @@ jest.mock('./recorder.utils', () => ({
 }));
 
 jest.mock('../common/output-stream', () => ({
-  ...jest.requireActual('../common/output-stream'),
   writeRecordings: jest.fn(),
 }));
 
 jest.mock('./matcher', () => ({
-  ...jest.requireActual('./matcher'),
   matchTraffic: jest.fn(),
 }));
 

--- a/src/nock/recorder.ts
+++ b/src/nock/recorder.ts
@@ -253,10 +253,7 @@ export async function endRecording({
 
       await writeRecordings(path, result.file);
     } else if (result.kind === 'new') {
-      const analysis = await matchTraffic(
-        result.oldRecordings ?? [],
-        definitions
-      );
+      const analysis = await matchTraffic(result.oldRecordings, definitions);
 
       debugRecordings('Matched incoming traffic with old one', analysis);
 

--- a/src/nock/recorder.utils.test.ts
+++ b/src/nock/recorder.utils.test.ts
@@ -42,7 +42,6 @@ const recordingsConfig = {
 };
 
 jest.mock('../common/io', () => ({
-  ...jest.requireActual('../common/io'),
   exists: jest.fn(),
   readFileQuiet: jest.fn(),
   mkdirQuiet: jest.fn(),
@@ -51,7 +50,6 @@ jest.mock('../common/io', () => ({
 }));
 
 jest.mock('../common/output-stream', () => ({
-  ...jest.requireActual('../common/output-stream'),
   writeRecordings: jest.fn(),
 }));
 

--- a/src/nock/recorder.utils.test.ts
+++ b/src/nock/recorder.utils.test.ts
@@ -1,0 +1,441 @@
+import { mocked } from 'ts-jest/utils';
+
+import {
+  RecordingsFileNotFoundError,
+  RecordingsHashNotFoundError,
+  RecordingsIndexNotFoundError,
+  UnexpectedError,
+} from '../common/errors';
+import {
+  exists,
+  mkdirQuiet,
+  readFileQuiet,
+  rename,
+  rimraf,
+} from '../common/io';
+import { writeRecordings } from '../common/output-stream';
+import {
+  canUpdateTraffic,
+  composeRecordingPath,
+  getRecordings,
+  handleRecordings,
+  parseRecordingsFile,
+  updateTraffic,
+} from './recorder.utils';
+import { RecordingType } from './recording.interfaces';
+
+const recordingsFilePath = 'path/to/recordings.json';
+const newRecordingsFilePath = 'path/to/recordings-new.json';
+const recordingsIndex = 'profile/provider/test';
+const recordingsHash = '###';
+
+const recordingsConfig = {
+  path: 'path/to/recordings',
+  type: RecordingType.MAIN,
+  key: recordingsIndex,
+  hash: recordingsHash,
+};
+
+jest.mock('../common/io', () => ({
+  ...jest.requireActual('../common/io'),
+  exists: jest.fn(),
+  readFileQuiet: jest.fn(),
+  mkdirQuiet: jest.fn(),
+  rename: jest.fn(),
+  rimraf: jest.fn(),
+}));
+
+jest.mock('../common/output-stream', () => ({
+  ...jest.requireActual('../common/output-stream'),
+  writeRecordings: jest.fn(),
+}));
+
+describe('Recorder utils', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('getRecordings', () => {
+    it('throws Error when no recordings file exist', async () => {
+      await expect(
+        getRecordings(
+          recordingsConfig.path,
+          RecordingType.MAIN,
+          recordingsConfig.key,
+          recordingsConfig.hash
+        )
+      ).rejects.toThrowError(
+        new RecordingsFileNotFoundError(recordingsFilePath)
+      );
+    });
+
+    describe('when using new recordings file', () => {
+      let env: string | undefined;
+
+      beforeAll(() => {
+        env = process.env.USE_NEW_TRAFFIC;
+        process.env.USE_NEW_TRAFFIC = 'true';
+      });
+
+      afterAll(() => {
+        process.env.USE_NEW_TRAFFIC = env;
+      });
+
+      it('throws Error when no new recordings file exist', async () => {
+        mocked(exists).mockResolvedValueOnce(true);
+
+        await expect(
+          getRecordings(
+            recordingsConfig.path,
+            RecordingType.MAIN,
+            recordingsConfig.key,
+            recordingsConfig.hash
+          )
+        ).rejects.toThrowError(
+          new RecordingsFileNotFoundError(newRecordingsFilePath)
+        );
+      });
+    });
+
+    it('throws Error when recordings file does not contain targeted recordings index', async () => {
+      mocked(exists).mockResolvedValue(true);
+      mocked(readFileQuiet).mockResolvedValue('{}');
+
+      await expect(
+        getRecordings(
+          recordingsConfig.path,
+          RecordingType.MAIN,
+          recordingsConfig.key,
+          recordingsConfig.hash
+        )
+      ).rejects.toThrowError(
+        new RecordingsIndexNotFoundError(
+          recordingsFilePath,
+          recordingsConfig.key
+        )
+      );
+    });
+
+    it('throws Error when recordings file does not contain targeted recordings hash', async () => {
+      mocked(exists).mockResolvedValue(true);
+      mocked(readFileQuiet).mockResolvedValue('{"profile/provider/test": {}}');
+
+      await expect(
+        getRecordings(
+          recordingsConfig.path,
+          RecordingType.MAIN,
+          recordingsConfig.key,
+          recordingsConfig.hash
+        )
+      ).rejects.toThrowError(
+        new RecordingsHashNotFoundError(
+          recordingsFilePath,
+          recordingsConfig.key,
+          recordingsConfig.hash
+        )
+      );
+    });
+
+    it('returns targeted recordings if they exist', async () => {
+      mocked(exists).mockResolvedValue(true);
+      mocked(readFileQuiet).mockResolvedValue(
+        '{"profile/provider/test": {"###":[]}}'
+      );
+
+      await expect(
+        getRecordings(
+          recordingsConfig.path,
+          RecordingType.MAIN,
+          recordingsConfig.key,
+          recordingsConfig.hash
+        )
+      ).resolves.toEqual([]);
+    });
+
+    it('returns recordings for prepare if they exist', async () => {
+      mocked(exists).mockResolvedValue(true);
+      mocked(readFileQuiet).mockResolvedValue(
+        '{"prepare-profile/provider/test": {"###":[]}}'
+      );
+
+      await expect(
+        getRecordings(
+          recordingsConfig.path,
+          RecordingType.PREPARE,
+          recordingsConfig.key,
+          recordingsConfig.hash
+        )
+      ).resolves.toEqual([]);
+    });
+
+    it('returns recordings for teardown if they exist', async () => {
+      mocked(exists).mockResolvedValue(true);
+      mocked(readFileQuiet).mockResolvedValue(
+        '{"teardown-profile/provider/test": {"###":[]}}'
+      );
+
+      await expect(
+        getRecordings(
+          recordingsConfig.path,
+          RecordingType.TEARDOWN,
+          recordingsConfig.key,
+          recordingsConfig.hash
+        )
+      ).resolves.toEqual([]);
+    });
+  });
+
+  describe('handleRecordings', () => {
+    describe('when recordings file does not exist', () => {
+      it('returns default with composed recordings file', async () => {
+        mocked(exists).mockResolvedValue(false);
+
+        await expect(
+          handleRecordings({
+            recordingsFilePath,
+            newRecordingsFilePath,
+            recordingsIndex,
+            recordingsHash,
+            recordings: [],
+            canSaveNewTraffic: false,
+          })
+        ).resolves.toEqual({
+          kind: 'default',
+          file: {
+            'profile/provider/test': {
+              '###': [],
+            },
+          },
+        });
+      });
+    });
+
+    describe('when recordings file exists', () => {
+      describe('and when targeted recordings are not present', () => {
+        it('merges current file with incoming traffic', async () => {
+          mocked(exists).mockResolvedValue(true);
+          mocked(readFileQuiet).mockResolvedValue(
+            '{"profile/provider/test": {"hash": []}}'
+          );
+
+          await expect(
+            handleRecordings({
+              recordingsFilePath,
+              newRecordingsFilePath,
+              recordingsIndex,
+              recordingsHash,
+              recordings: [],
+              canSaveNewTraffic: false,
+            })
+          ).resolves.toEqual({
+            kind: 'default',
+            file: {
+              'profile/provider/test': {
+                hash: [],
+                '###': [],
+              },
+            },
+          });
+        });
+      });
+
+      describe('and when targeted recordings are present', () => {
+        describe('and when present and incoming recordings are both empty', () => {
+          it('returns undefined - do not change anything', async () => {
+            mocked(exists).mockResolvedValue(true);
+            mocked(readFileQuiet).mockResolvedValue(
+              '{"profile/provider/test": {"###": []}}'
+            );
+
+            await expect(
+              handleRecordings({
+                recordingsFilePath,
+                newRecordingsFilePath,
+                recordingsIndex,
+                recordingsHash,
+                recordings: [],
+                canSaveNewTraffic: false,
+              })
+            ).resolves.toBeUndefined();
+          });
+        });
+
+        describe('and when storing new recordings is allowed', () => {
+          it('returns new with composed new recordings file and old targeted recordings', async () => {
+            // checking for current recordings file
+            mocked(exists).mockResolvedValueOnce(true);
+            // parsing current recordings file
+            mocked(readFileQuiet).mockResolvedValueOnce(
+              '{"profile/provider/test": {"###": [{}]}}'
+            );
+
+            // checking for new recordings file
+            mocked(exists).mockResolvedValueOnce(true);
+            // parsing new recordings file
+            mocked(readFileQuiet).mockResolvedValueOnce(
+              '{"profile/provider/test": {"hash": []}}'
+            );
+
+            await expect(
+              handleRecordings({
+                recordingsFilePath,
+                newRecordingsFilePath,
+                recordingsIndex,
+                recordingsHash,
+                recordings: [],
+                canSaveNewTraffic: true,
+              })
+            ).resolves.toEqual({
+              kind: 'new',
+              file: { 'profile/provider/test': { hash: [], '###': [] } },
+              oldRecordings: [{}],
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('composeRecordingPath', () => {
+    describe('when version is not specified', () => {
+      it('returns path to current recordings file', () => {
+        expect(composeRecordingPath(recordingsConfig.path)).toBe(
+          recordingsFilePath
+        );
+      });
+    });
+
+    describe('when specified version is "new"', () => {
+      it('returns path to new recordings file', () => {
+        expect(composeRecordingPath(recordingsConfig.path, 'new')).toBe(
+          newRecordingsFilePath
+        );
+      });
+    });
+
+    describe('when specified version is different than "new"', () => {
+      it('returns path to versioned recordings file', () => {
+        expect(composeRecordingPath(recordingsConfig.path, '1')).toBe(
+          'path/to/old/recordings_1.json'
+        );
+      });
+    });
+  });
+
+  describe('parseRecordingsFile', () => {
+    it('throws when reading fails', async () => {
+      mocked(readFileQuiet).mockResolvedValue(undefined);
+
+      await expect(
+        parseRecordingsFile(recordingsConfig.path)
+      ).rejects.toThrowError(
+        new UnexpectedError('Reading new recording file failed')
+      );
+    });
+
+    it('parses file if reading succeeds', async () => {
+      mocked(readFileQuiet).mockResolvedValue(
+        '{"profile/provider/test": {"###":[]}}'
+      );
+
+      await expect(parseRecordingsFile(recordingsConfig.path)).resolves.toEqual(
+        {
+          'profile/provider/test': {
+            '###': [],
+          },
+        }
+      );
+    });
+  });
+
+  describe('updateTraffic', () => {
+    it('updates current recording file with new traffic', async () => {
+      const mkdirSpy = mocked(mkdirQuiet);
+      const existSpy = mocked(exists).mockResolvedValueOnce(true);
+      const readFileSpy = mocked(readFileQuiet);
+      const renameSpy = mocked(rename);
+      const writeRecordingsSpy = mocked(writeRecordings);
+      const rimrafSpy = mocked(rimraf);
+
+      // current recordings file
+      readFileSpy.mockResolvedValueOnce(
+        '{"profile/provider/test": {"###":[], "hash": []}}'
+      );
+
+      // new recordings file
+      readFileSpy.mockResolvedValueOnce(
+        '{"profile/provider/test": {"###":[{"scope": "http://localhost"}]}}'
+      );
+
+      await expect(
+        updateTraffic(recordingsConfig.path)
+      ).resolves.toBeUndefined();
+
+      expect(mkdirSpy).toBeCalledTimes(1);
+      expect(mkdirSpy).toBeCalledWith('path/to/old');
+
+      expect(existSpy).toBeCalledTimes(2);
+      expect(existSpy).toHaveBeenNthCalledWith(
+        1,
+        'path/to/old/recordings_0.json'
+      );
+      expect(existSpy).toHaveBeenNthCalledWith(
+        2,
+        'path/to/old/recordings_1.json'
+      );
+
+      expect(readFileSpy).toBeCalledTimes(2);
+
+      expect(renameSpy).toBeCalledTimes(1);
+      expect(renameSpy).toBeCalledWith(
+        recordingsFilePath,
+        'path/to/old/recordings_1.json'
+      );
+
+      expect(writeRecordingsSpy).toBeCalledTimes(1);
+      expect(writeRecordingsSpy).toBeCalledWith(recordingsFilePath, {
+        'profile/provider/test': {
+          hash: [],
+          '###': [{ scope: 'http://localhost' }],
+        },
+      });
+
+      expect(rimrafSpy).toBeCalledTimes(1);
+      expect(rimrafSpy).toBeCalledWith(newRecordingsFilePath);
+    });
+  });
+
+  describe('canUpdateTraffic', () => {
+    it('returns false when env variable is not set', async () => {
+      await expect(
+        canUpdateTraffic(recordingsConfig.path)
+      ).resolves.toBeFalsy();
+    });
+
+    it('returns false when new recordings file does not exist', async () => {
+      const env = process.env.UPDATE_TRAFFIC;
+      process.env.UPDATE_TRAFFIC = 'true';
+
+      mocked(exists).mockResolvedValue(false);
+
+      await expect(
+        canUpdateTraffic(recordingsConfig.path)
+      ).resolves.toBeFalsy();
+
+      process.env.UPDATE_TRAFFIC = env;
+    });
+
+    it('returns true when new recordings file exists', async () => {
+      const env = process.env.UPDATE_TRAFFIC;
+      process.env.UPDATE_TRAFFIC = 'true';
+
+      mocked(exists).mockResolvedValue(true);
+
+      await expect(
+        canUpdateTraffic(recordingsConfig.path)
+      ).resolves.toBeTruthy();
+
+      process.env.UPDATE_TRAFFIC = env;
+    });
+  });
+});

--- a/src/nock/recorder.utils.ts
+++ b/src/nock/recorder.utils.ts
@@ -102,7 +102,7 @@ async function updateNewRecordingFile(
   return newRecordingsFile;
 }
 
-export async function updateRecordings({
+async function updateRecordings({
   recordingsFile,
   recordings,
   newRecordingsFilePath,
@@ -158,6 +158,48 @@ export async function updateRecordings({
   };
 
   return { kind: 'default', file: recordingsFile };
+}
+
+export async function handleRecordings({
+  recordingsFilePath,
+  newRecordingsFilePath,
+  recordingsIndex,
+  recordingsHash,
+  recordings,
+  canSaveNewTraffic,
+}: {
+  recordingsFilePath: string;
+  newRecordingsFilePath: string;
+  recordingsIndex: string;
+  recordingsHash: string;
+  recordings: RecordingDefinitions;
+  canSaveNewTraffic: boolean;
+}): Promise<UpdateResult | undefined> {
+  let recordingsFile: TestRecordings;
+
+  if (await exists(recordingsFilePath)) {
+    recordingsFile = await parseRecordingsFile(recordingsFilePath);
+
+    return await updateRecordings({
+      recordingsFile,
+      recordings: recordings,
+      newRecordingsFilePath,
+      recordingsIndex,
+      recordingsHash,
+      canSaveNewTraffic,
+    });
+  }
+
+  recordingsFile = {
+    [recordingsIndex]: {
+      [recordingsHash]: recordings,
+    },
+  };
+
+  return {
+    kind: 'default',
+    file: recordingsFile,
+  };
 }
 
 export function composeRecordingPath(

--- a/src/nock/recorder.utils.ts
+++ b/src/nock/recorder.utils.ts
@@ -1,0 +1,259 @@
+import createDebug from 'debug';
+import { basename, dirname, join as joinPath } from 'path';
+
+import { RecordingsNotFoundError, UnexpectedError } from '../common/errors';
+import {
+  exists,
+  mkdirQuiet,
+  readFileQuiet,
+  rename,
+  rimraf,
+} from '../common/io';
+import { writeRecordings } from '../common/output-stream';
+import { RecordingDefinitions } from '../superface-test.interfaces';
+import { parseBooleanEnv } from '../superface-test.utils';
+import { RecordingType, TestRecordings } from './recording.interfaces';
+
+const debug = createDebug('superface:testing');
+const debugRecordings = createDebug('superface:testing:recordings');
+
+export async function getRecordings(
+  recordingsPath: string,
+  recordingsType: RecordingType,
+  recordingsKey: string,
+  recordingsHash: string
+): Promise<RecordingDefinitions> {
+  // try to get new recordings if environment variable is set
+  const path = composeRecordingPath(recordingsPath);
+  const recordingsFileExists = await exists(path);
+
+  if (!recordingsFileExists) {
+    throw new RecordingsNotFoundError(path);
+  }
+
+  const useNewTraffic = parseBooleanEnv(process.env.USE_NEW_TRAFFIC);
+  const newRecordingsPath = composeRecordingPath(recordingsPath, 'new');
+  const newRecordingsFileExists = await exists(newRecordingsPath);
+
+  if (useNewTraffic && !newRecordingsFileExists) {
+    throw new RecordingsNotFoundError(newRecordingsPath);
+  }
+
+  const finalPath = useNewTraffic ? newRecordingsPath : path;
+  const recordingsIndex =
+    recordingsType !== RecordingType.MAIN
+      ? `${recordingsType}-${recordingsKey}`
+      : recordingsKey;
+
+  const recordings = (await parseRecordingsFile(finalPath))[recordingsIndex];
+
+  if (recordings === undefined) {
+    throw new Error(
+      `Recording under ${recordingsIndex} can't be found at ${finalPath}.`
+    );
+  }
+
+  const finalRecordings = recordings[recordingsHash];
+
+  // TODO: add new specific error
+  if (finalRecordings === undefined) {
+    throw new UnexpectedError(
+      `Recordings under hash ${recordingsHash} are not found. At ${finalPath}`
+    );
+  }
+
+  return finalRecordings;
+}
+
+export type UpdateResult =
+  | { kind: 'default'; file: TestRecordings }
+  | {
+      kind: 'new';
+      file: TestRecordings;
+      oldRecordings: RecordingDefinitions;
+    };
+
+async function updateNewRecordingFile(
+  newRecordingsFilePath: string,
+  recordingsIndex: string,
+  recordingsHash: string,
+  recordings: RecordingDefinitions
+): Promise<TestRecordings> {
+  let newRecordingsFile: TestRecordings;
+
+  if (await exists(newRecordingsFilePath)) {
+    newRecordingsFile = await parseRecordingsFile(newRecordingsFilePath);
+
+    newRecordingsFile = {
+      ...newRecordingsFile,
+      [recordingsIndex]: {
+        ...newRecordingsFile[recordingsIndex],
+        [recordingsHash]: recordings,
+      },
+    };
+  } else {
+    newRecordingsFile = {
+      [recordingsIndex]: {
+        [recordingsHash]: recordings,
+      },
+    };
+  }
+
+  return newRecordingsFile;
+}
+
+export async function updateRecordings({
+  recordingsFile,
+  recordings,
+  newRecordingsFilePath,
+  recordingsIndex,
+  recordingsHash,
+  canSaveNewTraffic,
+}: {
+  recordingsFile: TestRecordings;
+  recordings: RecordingDefinitions;
+  newRecordingsFilePath: string;
+  recordingsIndex: string;
+  recordingsHash: string;
+  canSaveNewTraffic: boolean;
+}): Promise<UpdateResult | undefined> {
+  const targetRecordings = findRecordings(
+    recordingsFile,
+    recordingsIndex,
+    recordingsHash
+  );
+
+  // if there already exist recordings for specified hash with empty list
+  // do not overwrite - return
+  if (
+    targetRecordings !== undefined &&
+    targetRecordings.length === 0 &&
+    recordings.length === 0
+  ) {
+    return undefined;
+  }
+
+  // if there already exist recordings for specified hash with some recordings
+  // save new traffic to new file
+  if (canSaveNewTraffic && targetRecordings !== undefined) {
+    return {
+      kind: 'new',
+      file: await updateNewRecordingFile(
+        newRecordingsFilePath,
+        recordingsIndex,
+        recordingsHash,
+        recordings
+      ),
+      oldRecordings: targetRecordings,
+    };
+  }
+
+  // otherwise store specified recordings to default file
+  recordingsFile = {
+    ...recordingsFile,
+    [recordingsIndex]: {
+      ...recordingsFile[recordingsIndex],
+      [recordingsHash]: recordings,
+    },
+  };
+
+  return { kind: 'default', file: recordingsFile };
+}
+
+export function composeRecordingPath(
+  recordingPath: string,
+  version?: string
+): string {
+  if (version === 'new') {
+    return `${recordingPath}-new.json`;
+  }
+
+  if (version !== undefined) {
+    const baseDir = dirname(recordingPath);
+    const baseName = basename(recordingPath);
+
+    return joinPath(baseDir, 'old', `${baseName}_${version}.json`);
+  }
+
+  return `${recordingPath}.json`;
+}
+
+function findRecordings(
+  recordingsFile: TestRecordings,
+  recordingsIndex: string,
+  recordingsHash: string
+): RecordingDefinitions | undefined {
+  if (recordingsFile[recordingsIndex] === undefined) {
+    return undefined;
+  }
+
+  return recordingsFile[recordingsIndex][recordingsHash];
+}
+
+export async function parseRecordingsFile(
+  path: string
+): Promise<TestRecordings> {
+  const definitionFile = await readFileQuiet(path);
+
+  if (definitionFile === undefined) {
+    throw new UnexpectedError('Reading new recording file failed');
+  }
+
+  debug(`Parsing recording file at: "${path}"`);
+
+  return JSON.parse(definitionFile) as TestRecordings;
+}
+
+export async function updateTraffic(recordingPath: string): Promise<void> {
+  const pathToCurrent = composeRecordingPath(recordingPath);
+  const pathToNew = composeRecordingPath(recordingPath, 'new');
+
+  await mkdirQuiet(joinPath(dirname(pathToCurrent), 'old'));
+
+  // TODO: compose version based on used map
+  let i = 0;
+  while (await exists(composeRecordingPath(recordingPath, `${i}`))) {
+    i++;
+  }
+
+  const currentTestFile = await parseRecordingsFile(pathToCurrent);
+  const newTestFile = await parseRecordingsFile(pathToNew);
+
+  debugRecordings('Current recordings file:', currentTestFile);
+  debugRecordings('New recordings file:', newTestFile);
+
+  // loop through new file and merge it with current one
+  for (const [index, recordOfRecordings] of Object.entries(newTestFile)) {
+    if (currentTestFile[index] === undefined) {
+      currentTestFile[index] = recordOfRecordings;
+    } else {
+      for (const [hash, recordings] of Object.entries(recordOfRecordings)) {
+        currentTestFile[index][hash] = recordings;
+      }
+    }
+  }
+
+  debugRecordings('Current recordings file after merge:', currentTestFile);
+
+  // move old current file to directory /old
+  await rename(pathToCurrent, composeRecordingPath(recordingPath, `${i}`));
+  // write merged file in place of current file
+  await writeRecordings(pathToCurrent, currentTestFile);
+  // remove new file
+  await rimraf(pathToNew);
+}
+
+export async function canUpdateTraffic(
+  recordingPath: string
+): Promise<boolean> {
+  const updateTraffic = parseBooleanEnv(process.env.UPDATE_TRAFFIC);
+
+  if (
+    updateTraffic &&
+    (await exists(composeRecordingPath(recordingPath, 'new')))
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/nock/recording.interfaces.ts
+++ b/src/nock/recording.interfaces.ts
@@ -1,14 +1,8 @@
-import { ReplyBody } from 'nock/types';
-
-import { RecordingDefinition } from '../superface-test.interfaces';
-
-export type RecordingWithDecodedResponse = RecordingDefinition & {
-  decodedResponse: ReplyBody;
-};
+import { RecordingDefinitions } from '../superface-test.interfaces';
 
 export type TestRecordings = Record<
   string,
-  Record<string, RecordingWithDecodedResponse[]>
+  Record<string, RecordingDefinitions>
 >;
 
 export enum RecordingType {

--- a/src/nock/recording.interfaces.ts
+++ b/src/nock/recording.interfaces.ts
@@ -6,14 +6,13 @@ export type RecordingWithDecodedResponse = RecordingDefinition & {
   decodedResponse: ReplyBody;
 };
 
-export interface TestRecordings {
-  main: Record<string, RecordingWithDecodedResponse[]>;
-  prepare?: Record<string, RecordingWithDecodedResponse[]>;
-  teardown?: Record<string, RecordingWithDecodedResponse[]>;
-}
+export type TestRecordings = Record<
+  string,
+  Record<string, RecordingWithDecodedResponse[]>
+>;
 
 export enum RecordingType {
-  TEST = 'test',
+  MAIN = 'main',
   PREPARE = 'prepare',
   TEARDOWN = 'teardown',
 }

--- a/src/nock/recording.interfaces.ts
+++ b/src/nock/recording.interfaces.ts
@@ -1,0 +1,19 @@
+import { ReplyBody } from 'nock/types';
+
+import { RecordingDefinition } from '../superface-test.interfaces';
+
+export type RecordingWithDecodedResponse = RecordingDefinition & {
+  decodedResponse: ReplyBody;
+};
+
+export interface TestRecordings {
+  main: Record<string, RecordingWithDecodedResponse[]>;
+  prepare?: Record<string, RecordingWithDecodedResponse[]>;
+  teardown?: Record<string, RecordingWithDecodedResponse[]>;
+}
+
+export enum RecordingType {
+  TEST = 'test',
+  PREPARE = 'prepare',
+  TEARDOWN = 'teardown',
+}

--- a/src/reporter.test.ts
+++ b/src/reporter.test.ts
@@ -18,7 +18,7 @@ const sampleAnalysisResult: ImpactResult = {
   impact: MatchImpact.PATCH,
 };
 const sampleTestResult = {
-  recordingPath: '',
+  recordingsPath: 'path/to/recording.json',
   profileId: 'profile',
   providerName: 'provider',
   useCaseName: 'test',
@@ -47,7 +47,7 @@ describe('Reporter module', () => {
         saveReport({
           input: {},
           result: ok(''),
-          hash: sampleHash,
+          recordingsHash: sampleHash,
           analysis: sampleAnalysisResult,
           ...sampleTestResult,
         })
@@ -72,7 +72,7 @@ describe('Reporter module', () => {
       await saveReport({
         input: {},
         result: ok(''),
-        hash: sampleHash,
+        recordingsHash: sampleHash,
         analysis: sampleAnalysisResult,
         ...sampleTestResult,
       });

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -25,17 +25,17 @@ const debug = createDebug('superface:testing:reporter');
 export async function saveReport({
   input,
   result,
-  hash,
+  recordingsHash,
+  recordingsPath,
   analysis,
-  recordingPath,
   profileId,
   providerName,
   useCaseName,
 }: {
   input: NonPrimitive;
   result: TestingReturn;
-  hash: string;
-  recordingPath: string;
+  recordingsHash: string;
+  recordingsPath: string;
   analysis: ImpactResult;
   profileId: string;
   providerName: string;
@@ -45,12 +45,12 @@ export async function saveReport({
   const coveragePath = joinPath(
     DEFAULT_COVERAGE_PATH,
     getFixtureName(profileId, providerName, useCaseName),
-    `coverage-${hash}.json`
+    `coverage-${recordingsHash}.json`
   );
 
   const data: TestAnalysis = {
     ...analysis,
-    recordingPath,
+    recordingsPath,
     profileId,
     providerName,
     useCaseName,

--- a/src/superface-test.interfaces.ts
+++ b/src/superface-test.interfaces.ts
@@ -54,6 +54,8 @@ export type ProcessingFunction = (
 ) => Promise<void> | void;
 
 export interface RecordingProcessOptions {
+  prepare?: boolean;
+  teardown?: boolean;
   processRecordings?: boolean;
   beforeRecordingSave?: ProcessingFunction;
   beforeRecordingLoad?: ProcessingFunction;
@@ -77,7 +79,7 @@ export type TestAnalysis = {
   profileId: string;
   providerName: string;
   useCaseName: string;
-  recordingPath: string;
+  recordingsPath: string;
   input: NonPrimitive;
   result: TestingReturn;
   errors: ErrorCollection<string>;

--- a/src/superface-test.interfaces.ts
+++ b/src/superface-test.interfaces.ts
@@ -9,7 +9,7 @@ import {
   UnexpectedError,
   UseCase,
 } from '@superfaceai/one-sdk';
-import { Definition } from 'nock/types';
+import { Definition, ReplyBody } from 'nock/types';
 
 import { MatchImpact } from './nock/analyzer';
 import { ErrorCollection, MatchError } from './nock/matcher.errors';
@@ -46,6 +46,7 @@ export interface NockConfig {
 
 export type RecordingDefinition = Definition & {
   rawHeaders?: string[];
+  decodedResponse?: ReplyBody;
 };
 export type RecordingDefinitions = RecordingDefinition[];
 

--- a/src/superface-test.interfaces.ts
+++ b/src/superface-test.interfaces.ts
@@ -13,6 +13,7 @@ import { Definition, ReplyBody } from 'nock/types';
 
 import { MatchImpact } from './nock/analyzer';
 import { ErrorCollection, MatchError } from './nock/matcher.errors';
+import { RecordingType } from './nock/recording.interfaces';
 
 export interface SuperfaceTestConfig {
   profile?: Profile | string;
@@ -55,8 +56,7 @@ export type ProcessingFunction = (
 ) => Promise<void> | void;
 
 export interface RecordingProcessOptions {
-  prepare?: boolean;
-  teardown?: boolean;
+  recordingType?: RecordingType;
   processRecordings?: boolean;
   beforeRecordingSave?: ProcessingFunction;
   beforeRecordingLoad?: ProcessingFunction;

--- a/src/superface-test.test.ts
+++ b/src/superface-test.test.ts
@@ -7,7 +7,7 @@ import {
   ServiceSelector,
 } from '@superfaceai/one-sdk';
 import nock, { pendingMocks, recorder } from 'nock';
-import { join as joinPath, resolve as resolvePath } from 'path';
+import { join as joinPath } from 'path';
 import { mocked } from 'ts-jest/utils';
 
 import { RecordingsFileNotFoundError } from './common/errors';
@@ -73,7 +73,7 @@ const testPayload = {
 const pathToRecordings = joinPath(
   process.cwd(),
   'recordings',
-  ...Object.values(testPayload)
+  testPayload.profile
 );
 
 const DEFAULT_RECORDING_NEXT_TO_TEST_PATH = joinPath(
@@ -645,10 +645,6 @@ describe('SuperfaceTest', () => {
 
       it('throws when recording fixture does not exist', async () => {
         const testName = 'my-test-name';
-        const recordingPath = resolvePath(
-          `recordings/${testPayload.profile}/${testPayload.provider}/${testPayload.useCase}/${testPayload.provider}.recording.json`
-        );
-
         const recorderSpy = jest.spyOn(recorder, 'rec');
         const defineRecordingSpy = jest.spyOn(nock, 'define');
 
@@ -657,7 +653,9 @@ describe('SuperfaceTest', () => {
 
         await expect(
           superfaceTest.run({ input: {}, testName })
-        ).rejects.toThrowError(new RecordingsFileNotFoundError(recordingPath));
+        ).rejects.toThrowError(
+          new RecordingsFileNotFoundError(DEFAULT_RECORDING_PATH)
+        );
 
         expect(recorderSpy).not.toHaveBeenCalled();
         expect(defineRecordingSpy).not.toHaveBeenCalled();

--- a/src/superface-test.test.ts
+++ b/src/superface-test.test.ts
@@ -6,17 +6,14 @@ import {
   ok,
   ServiceSelector,
 } from '@superfaceai/one-sdk';
-import nock, { pendingMocks, recorder } from 'nock';
+import nock, { pendingMocks } from 'nock';
 import { join as joinPath } from 'path';
 import { mocked } from 'ts-jest/utils';
 
-import { RecordingsFileNotFoundError } from './common/errors';
 import { matchWildCard } from './common/format';
-import { exists, readFileQuiet } from './common/io';
-import { writeRecordings } from './common/output-stream';
+
 import { generate } from './generate-hash';
-import { Matcher } from './nock/matcher';
-import { MatchErrorResponse } from './nock/matcher.errors';
+import { MatchErrorLength } from './nock/matcher.errors';
 import { endRecording, loadRecording, startRecording } from './nock/recorder';
 import { RecordingType } from './nock/recording.interfaces';
 import { saveReport } from './reporter';
@@ -28,11 +25,8 @@ import {
   InputVariables,
   RecordingDefinitions,
 } from './superface-test.interfaces';
-import {
-  HIDDEN_CREDENTIALS_PLACEHOLDER,
-  HIDDEN_INPUT_PLACEHOLDER,
-  HIDDEN_PARAMETERS_PLACEHOLDER,
-} from './superface-test.utils';
+import { MatchImpact } from './nock/analyzer';
+import { canUpdateTraffic, updateTraffic } from './nock/recorder.utils';
 
 /* eslint-disable @typescript-eslint/unbound-method */
 
@@ -48,16 +42,17 @@ jest.mock('./common/format', () => ({
   matchWildCard: jest.fn(),
 }));
 
-// jest.mock('./nock/recorder', () => ({
-//   ...jest.requireActual('./nock/recorder'),
-//   startRecording: jest.fn(),
-//   endRecording: jest.fn(),
-//   loadRecording: jest.fn(),
-// }));
+jest.mock('./nock/recorder', () => ({
+  ...jest.requireActual('./nock/recorder'),
+  startRecording: jest.fn(),
+  endRecording: jest.fn(),
+  loadRecording: jest.fn(),
+}));
 
-jest.mock('./common/output-stream', () => ({
-  ...jest.requireActual('./common/output-stream'),
-  writeRecordings: jest.fn(),
+jest.mock('./nock/recorder.utils', () => ({
+  ...jest.requireActual('./nock/recorder.utils'),
+  canUpdateTraffic: jest.fn(),
+  updateTraffic: jest.fn(),
 }));
 
 jest.mock('./reporter', () => ({
@@ -74,22 +69,6 @@ const pathToRecordings = joinPath(
   process.cwd(),
   'recordings',
   testPayload.profile
-);
-
-const DEFAULT_RECORDING_NEXT_TO_TEST_PATH = joinPath(
-  '.',
-  'recordings',
-  'provider.recording.json'
-);
-
-const DEFAULT_RECORDING_PATH = joinPath(
-  pathToRecordings,
-  'provider.recording.json'
-);
-
-const DEFAULT_NEW_RECORDING_PATH = joinPath(
-  pathToRecordings,
-  'provider.recording-new.json'
 );
 
 const defaultInput = {};
@@ -126,7 +105,7 @@ const prepareBoundProfileProvider = (options?: {
   });
 };
 
-const prepareLoadRecordingParameters = (options?: {
+interface RecordingsOptions {
   recordingsPath?: string;
   recordingsType?: RecordingType;
   recordingsHash?: string;
@@ -136,14 +115,23 @@ const prepareLoadRecordingParameters = (options?: {
     boundProfileProvider?: Parameters<typeof prepareBoundProfileProvider>;
     providerName?: string;
   };
-  beforeRecordingLoad?: boolean;
   processRecordings?: boolean;
-}): Parameters<typeof loadRecording> => [
+}
+
+const prepareRecordingsConfig = (options?: RecordingsOptions) => ({
+  recordingsPath: options?.recordingsPath ?? recordingsConfig.path,
+  recordingsType: options?.recordingsType ?? RecordingType.MAIN,
+  recordingsHash: options?.recordingsHash ?? recordingsConfig.hash,
+  recordingsKey: options?.recordingsKey ?? recordingsConfig.key,
+});
+
+const prepareLoadRecordingParameters = (
+  options?: RecordingsOptions & {
+    beforeRecordingLoad?: boolean;
+  }
+) => [
   {
-    recordingsPath: options?.recordingsPath ?? recordingsConfig.path,
-    recordingsType: options?.recordingsType ?? RecordingType.MAIN,
-    recordingsHash: options?.recordingsHash ?? recordingsConfig.hash,
-    recordingsKey: options?.recordingsKey ?? recordingsConfig.key,
+    ...prepareRecordingsConfig(options),
     inputVariables: options?.inputVariables,
     config: {
       boundProfileProvider: prepareBoundProfileProvider(
@@ -161,60 +149,51 @@ const prepareLoadRecordingParameters = (options?: {
   },
 ];
 
-const prepareEndRecordingParameters = (options?: {
-  recordingsPath?: string;
-  recordingsType?: RecordingType;
-  recordingsHash?: string;
-  recordingsKey?: string;
-  inputVariables: InputVariables;
-  config?: {
-    boundProfileProvider?: Parameters<typeof prepareBoundProfileProvider>;
-    providerName?: string;
-  };
-  beforeRecordingSave?: boolean;
-  processRecordings?: boolean;
-}) => ({
-  recordingsPath: options?.recordingsPath ?? recordingsConfig.path,
-  recordingsType: options?.recordingsType ?? RecordingType.MAIN,
-  recordingsHash: options?.recordingsHash ?? recordingsConfig.hash,
-  recordingsKey: options?.recordingsKey ?? recordingsConfig.key,
-  inputVariables: options?.inputVariables,
-  config: {
-    boundProfileProvider: prepareBoundProfileProvider(
-      ...(options?.config?.boundProfileProvider ?? [])
-    ),
-    providerName: options?.config?.providerName ?? 'provider',
+const prepareEndRecordingParameters = (
+  options?: RecordingsOptions & {
+    beforeRecordingSave?: boolean;
+  }
+) => [
+  {
+    ...prepareRecordingsConfig(options),
+    inputVariables: options?.inputVariables,
+    config: {
+      boundProfileProvider: prepareBoundProfileProvider(
+        ...(options?.config?.boundProfileProvider ?? [])
+      ),
+      providerName: options?.config?.providerName ?? 'provider',
+    },
+    options: {
+      beforeRecordingSave: options?.beforeRecordingSave
+        ? /* eslint-disable-next-line @typescript-eslint/no-empty-function */
+          (_: RecordingDefinitions) => {}
+        : undefined,
+      processRecordings: options?.processRecordings ?? true,
+    },
   },
-  options: {
-    beforeRecordingSave: options?.beforeRecordingSave
-      ? /* eslint-disable-next-line @typescript-eslint/no-empty-function */
-        (_: RecordingDefinitions) => {}
-      : undefined,
-    processRecordings: options?.processRecordings ?? true,
-  },
-});
+];
 
 describe('SuperfaceTest', () => {
   let superfaceTest: SuperfaceTest;
 
+  beforeEach(() => {
+    superfaceTest = new SuperfaceTest(testPayload);
+  });
+
   afterEach(() => {
-    mocked(exists).mockReset();
-    mocked(matchWildCard).mockReset();
-    mocked(writeRecordings).mockReset();
-    mocked(saveReport).mockReset();
     mockBoundProfileProvider.mockClear();
-    // mocked(startRecording).mockReset();
-    // mocked(endRecording).mockReset();
-    // mocked(loadRecording).mockReset();
+    mocked(matchWildCard).mockReset();
+    mocked(canUpdateTraffic).mockReset();
+    mocked(updateTraffic).mockReset();
+    mocked(startRecording).mockReset();
+    mocked(loadRecording).mockReset();
+    mocked(endRecording).mockReset();
+    mocked(saveReport).mockReset();
   });
 
   describe('run', () => {
     describe('when recording', () => {
-      beforeEach(() => {
-        superfaceTest = new SuperfaceTest(testPayload);
-      });
-
-      it.skip('writes and restores recordings', async () => {
+      it('writes and restores recordings', async () => {
         const startRecordingSpy = mocked(startRecording);
         const endRecordingSpy = mocked(endRecording);
 
@@ -230,438 +209,45 @@ describe('SuperfaceTest', () => {
         );
       });
 
-      it('writes recordings when no traffic was recorded', async () => {
-        const writeRecordingsSpy = mocked(writeRecordings);
-        const recorderSpy = jest.spyOn(recorder, 'rec');
-        jest.spyOn(recorder, 'play').mockReturnValueOnce([]);
+      it('saves report if new recording contains some changes', async () => {
+        const saveReportSpy = mocked(saveReport);
 
-        mocked(matchWildCard).mockReturnValueOnce(true);
         mocked(prepareSuperface).mockResolvedValue(mockSuperface());
+        mocked(matchWildCard).mockReturnValueOnce(true);
+        mocked(endRecording).mockResolvedValue({
+          impact: MatchImpact.MAJOR,
+          errors: {
+            added: [new MatchErrorLength(1, 2)],
+            removed: [],
+            changed: [],
+          },
+        });
 
         await superfaceTest.run({ input: defaultInput });
 
-        expect(recorderSpy).toHaveBeenCalledTimes(1);
-
-        expect(writeRecordingsSpy).toHaveBeenCalledWith(
-          expect.stringMatching(DEFAULT_RECORDING_PATH),
-          {
-            'profile/provider/test': {
-              [defaultExpectedHash]: [],
-            },
-          }
-        );
-      });
-
-      it('writes and restores modified recordings when security is used', async () => {
-        const secret = 'secret';
-
-        const writeRecordingsSpy = mocked(writeRecordings);
-        jest.spyOn(recorder, 'play').mockReturnValueOnce([
-          {
-            scope: 'https://localhost',
-            path: `/?api_key=${secret}`,
-            status: 200,
-            response: { auth: secret },
-          },
-        ]);
-
-        mocked(matchWildCard).mockReturnValueOnce(true);
-        mocked(prepareSuperface).mockResolvedValue(
-          mockSuperface({
-            boundProfileProvider: {
-              result: err(new MapASTError('error')),
-              security: [
-                {
-                  id: 'api-key',
-                  type: SecurityType.APIKEY,
-                  in: ApiKeyPlacement.QUERY,
-                  name: 'api_key',
-                  apikey: secret,
-                },
-              ],
-            },
-          })
-        );
-
-        await superfaceTest.run({ input: defaultInput });
-
-        expect(writeRecordingsSpy).toHaveBeenCalledWith(
-          expect.stringMatching(DEFAULT_RECORDING_PATH),
-          {
-            'profile/provider/test': {
-              [defaultExpectedHash]: [
-                {
-                  scope: 'https://localhost',
-                  path: `/?api_key=${HIDDEN_CREDENTIALS_PLACEHOLDER}api-key`,
-                  status: 200,
-                  response: {
-                    auth: `${HIDDEN_CREDENTIALS_PLACEHOLDER}api-key`,
-                  },
-                },
-              ],
-            },
-          }
-        );
-      });
-
-      it('writes and restores modified recordings when integration parameters are used', async () => {
-        const param = 'integration-parameter';
-
-        const writeRecordingsSpy = mocked(writeRecordings);
-        jest.spyOn(recorder, 'play').mockReturnValueOnce([
-          {
-            scope: 'https://localhost',
-            path: `/?api_key=${param}`,
-            status: 200,
-            response: { auth: param },
-          },
-        ]);
-
-        mocked(matchWildCard).mockReturnValueOnce(true);
-        mocked(prepareSuperface).mockResolvedValue(
-          mockSuperface({
-            boundProfileProvider: {
-              result: err(new MapASTError('error')),
-              parameters: {
-                param,
-              },
-            },
-          })
-        );
-
-        await superfaceTest.run({ input: defaultInput });
-
-        expect(writeRecordingsSpy).toHaveBeenCalledWith(
-          expect.stringMatching(DEFAULT_RECORDING_PATH),
-          {
-            'profile/provider/test': {
-              [defaultExpectedHash]: [
-                {
-                  scope: 'https://localhost',
-                  path: `/?api_key=${HIDDEN_PARAMETERS_PLACEHOLDER}param`,
-                  status: 200,
-                  response: {
-                    auth: `${HIDDEN_PARAMETERS_PLACEHOLDER}param`,
-                  },
-                },
-              ],
-            },
-          }
-        );
-      });
-
-      it('writes and restores modified recordings when hiding input is used', async () => {
-        const token = 'secret';
-        const refresh = 'refresh-token';
-
-        const writeRecordingsSpy = mocked(writeRecordings);
-        jest.spyOn(recorder, 'play').mockReturnValueOnce([
-          {
-            scope: 'https://localhost',
-            path: `/?token=${token}`,
-            status: 200,
-            response: {
-              auth: {
-                value: token,
-                refresh,
-              },
-            },
-          },
-        ]);
-
-        mocked(matchWildCard).mockReturnValueOnce(true);
-        mocked(prepareSuperface).mockResolvedValue(mockSuperface());
-
-        const input = { auth: { token, refresh } };
-        const expectedHash = generate(JSON.stringify(input));
-
-        await superfaceTest.run(
-          { input },
-          { hideInput: ['auth.token', 'auth.refresh'] }
-        );
-
-        expect(writeRecordingsSpy).toHaveBeenCalledWith(
-          expect.stringMatching(DEFAULT_RECORDING_PATH),
-          {
-            'profile/provider/test': {
-              [expectedHash]: [
-                {
-                  scope: 'https://localhost',
-                  path: `/?token=${HIDDEN_INPUT_PLACEHOLDER}auth.token`,
-                  status: 200,
-                  response: {
-                    auth: {
-                      value: `${HIDDEN_INPUT_PLACEHOLDER}auth.token`,
-                      refresh: `${HIDDEN_INPUT_PLACEHOLDER}auth.refresh`,
-                    },
-                  },
-                },
-              ],
-            },
-          }
-        );
-      });
-
-      describe('and when old traffic already exists', () => {
-        describe('and when saving to new files is enabled', () => {
-          beforeEach(() => {
-            process.env.STORE_NEW_TRAFFIC = 'true';
-          });
-
-          afterEach(() => {
-            process.env.STORE_NEW_TRAFFIC = undefined;
-          });
-
-          it('does not write recordings when old and new traffic match', async () => {
-            const sampleRecording = {
-              scope: 'https://localhost',
-              path: `/path`,
-              status: 200,
-              response: { value: 1 },
-            };
-
-            const writeRecordingsSpy = mocked(writeRecordings);
-            const matcherSpy = jest
-              .spyOn(Matcher, 'match')
-              .mockResolvedValue({ valid: true });
-
-            jest.spyOn(recorder, 'play').mockReturnValueOnce([sampleRecording]);
-            mocked(prepareSuperface).mockResolvedValue(mockSuperface());
-            mocked(exists).mockResolvedValue(true);
-            mocked(matchWildCard).mockReturnValueOnce(true);
-            mocked(readFileQuiet).mockResolvedValue(
-              JSON.stringify({
-                'profile/provider/test': {
-                  [defaultExpectedHash]: [sampleRecording],
-                },
-              })
-            );
-
-            await superfaceTest.run({ input: defaultInput });
-
-            expect(writeRecordingsSpy).not.toBeCalled();
-            expect(matcherSpy).toBeCalledTimes(1);
-            expect(matcherSpy).toBeCalledWith(
-              [sampleRecording],
-              [sampleRecording]
-            );
-          });
-
-          it('writes recordings when old and new traffic does not match', async () => {
-            const oldRecording = {
-              scope: 'https://localhost',
-              path: `/path`,
-              status: 200,
-              response: { value: 1 },
-            };
-
-            const newRecording = {
-              scope: 'https://localhost',
-              path: `/path`,
-              status: 200,
-              response: { new_value: 1 },
-            };
-
-            jest.spyOn(recorder, 'play').mockReturnValueOnce([newRecording]);
-
-            const writeRecordingsSpy = mocked(writeRecordings);
-            const errors = {
-              added: [],
+        expect(saveReportSpy).toBeCalledTimes(1);
+        expect(saveReportSpy).toBeCalledWith({
+          input: {},
+          result: ok('value'),
+          recordingsHash: recordingsConfig.hash,
+          recordingsPath: recordingsConfig.path,
+          profileId: testPayload.profile,
+          providerName: testPayload.provider,
+          useCaseName: testPayload.useCase,
+          analysis: {
+            impact: MatchImpact.MAJOR,
+            errors: {
+              added: [new MatchErrorLength(1, 2)],
               removed: [],
-              changed: [
-                new MatchErrorResponse(
-                  {
-                    oldResponse: { value: 1 },
-                    newResponse: { new_value: 1 },
-                  },
-                  'response property "value" is not present'
-                ),
-              ],
-            };
-            const matcherSpy = jest.spyOn(Matcher, 'match').mockResolvedValue({
-              valid: false,
-              errors,
-            });
-            const saveReportSpy = mocked(saveReport);
-
-            mocked(prepareSuperface).mockResolvedValue(mockSuperface());
-            mocked(exists).mockResolvedValue(true);
-            mocked(matchWildCard).mockReturnValueOnce(true);
-            mocked(readFileQuiet).mockResolvedValue(
-              JSON.stringify({
-                'profile/provider/test': {
-                  [defaultExpectedHash]: [oldRecording],
-                },
-              })
-            );
-
-            await superfaceTest.run({ input: defaultInput });
-
-            expect(matcherSpy).toBeCalledTimes(1);
-            expect(matcherSpy).toBeCalledWith([oldRecording], [newRecording]);
-
-            expect(writeRecordingsSpy).toBeCalledTimes(1);
-            expect(writeRecordingsSpy).toBeCalledWith(
-              expect.stringMatching(DEFAULT_NEW_RECORDING_PATH),
-              {
-                'profile/provider/test': {
-                  [defaultExpectedHash]: [newRecording],
-                },
-              }
-            );
-
-            expect(saveReportSpy).toBeCalledTimes(1);
-          });
-        });
-
-        describe('and when saving to new files is disabled (no matching)', () => {
-          it('overwrites recordings', async () => {
-            const sampleRecording = {
-              scope: 'https://localhost',
-              path: `/path`,
-              status: 200,
-              response: { value: 1 },
-            };
-
-            const writeRecordingsSpy = mocked(writeRecordings);
-            const saveReportSpy = mocked(saveReport);
-            const matcherSpy = jest.spyOn(Matcher, 'match');
-
-            jest.spyOn(recorder, 'play').mockReturnValueOnce([sampleRecording]);
-
-            mocked(prepareSuperface).mockResolvedValue(mockSuperface());
-            mocked(exists).mockResolvedValue(true);
-            mocked(matchWildCard).mockReturnValueOnce(true);
-            mocked(readFileQuiet).mockResolvedValue(
-              JSON.stringify({
-                'profile/provider/test': {
-                  [defaultExpectedHash]: [sampleRecording],
-                },
-              })
-            );
-
-            await superfaceTest.run({ input: defaultInput });
-
-            expect(matcherSpy).not.toBeCalled();
-
-            expect(writeRecordingsSpy).toBeCalledTimes(1);
-            expect(writeRecordingsSpy).toBeCalledWith(
-              expect.stringMatching(DEFAULT_RECORDING_PATH),
-              {
-                'profile/provider/test': {
-                  [defaultExpectedHash]: [sampleRecording],
-                },
-              }
-            );
-
-            expect(saveReportSpy).not.toBeCalled();
-          });
-        });
-      });
-    });
-
-    describe('when hashing recordings', () => {
-      beforeEach(async () => {
-        superfaceTest = new SuperfaceTest(testPayload, {
-          testInstance: expect,
-        });
-      });
-
-      it('writes recordings to file hashed based on test instance', async () => {
-        const expectedTestName = expect.getState().currentTestName;
-        const expectedHash = generate(expectedTestName);
-
-        const writeRecordingsSpy = mocked(writeRecordings);
-        jest.spyOn(recorder, 'play').mockReturnValueOnce([]);
-
-        mocked(matchWildCard).mockReturnValueOnce(true);
-        mocked(prepareSuperface).mockResolvedValue(mockSuperface());
-
-        await superfaceTest.run({ input: {} });
-
-        expect(writeRecordingsSpy).toHaveBeenCalledWith(
-          expect.stringMatching(DEFAULT_RECORDING_NEXT_TO_TEST_PATH),
-          {
-            'profile/provider/test': {
-              [expectedHash]: [],
+              changed: [],
             },
-          }
-        );
-      });
-
-      it('writes recordings to file hashed based on parameter testName', async () => {
-        const testName = 'my-test-name';
-        const expectedHash = generate(testName);
-
-        const writeRecordingsSpy = mocked(writeRecordings);
-        jest.spyOn(recorder, 'play').mockReturnValueOnce([]);
-
-        mocked(matchWildCard).mockReturnValueOnce(true);
-        mocked(prepareSuperface).mockResolvedValue(mockSuperface());
-
-        await superfaceTest.run({ input: {}, testName });
-
-        expect(writeRecordingsSpy).toHaveBeenCalledWith(
-          expect.stringMatching(DEFAULT_RECORDING_NEXT_TO_TEST_PATH),
-          {
-            'profile/provider/test': {
-              [expectedHash]: [],
-            },
-          }
-        );
-      });
-
-      it('writes recordings to file hashed based on input', async () => {
-        superfaceTest = new SuperfaceTest(testPayload, {
-          testInstance: undefined,
+          },
         });
-
-        const input = { some: 'value' };
-        const expectedHash = generate(JSON.stringify(input));
-
-        const writeRecordingsSpy = mocked(writeRecordings);
-        jest.spyOn(recorder, 'play').mockReturnValueOnce([]);
-
-        mocked(matchWildCard).mockReturnValueOnce(true);
-        mocked(prepareSuperface).mockResolvedValue(mockSuperface());
-
-        await superfaceTest.run({ input, testName: undefined });
-
-        expect(writeRecordingsSpy).toHaveBeenCalledWith(
-          expect.stringMatching(DEFAULT_RECORDING_PATH),
-          {
-            'profile/provider/test': {
-              [expectedHash]: [],
-            },
-          }
-        );
       });
     });
 
     describe('when loading recordings', () => {
-      beforeEach(() => {
-        superfaceTest = new SuperfaceTest(testPayload);
-      });
-
-      it('throws when recording fixture does not exist', async () => {
-        const testName = 'my-test-name';
-        const recorderSpy = jest.spyOn(recorder, 'rec');
-        const defineRecordingSpy = jest.spyOn(nock, 'define');
-
-        mocked(matchWildCard).mockReturnValueOnce(false);
-        mocked(prepareSuperface).mockResolvedValue(mockSuperface());
-
-        await expect(
-          superfaceTest.run({ input: {}, testName })
-        ).rejects.toThrowError(
-          new RecordingsFileNotFoundError(DEFAULT_RECORDING_PATH)
-        );
-
-        expect(recorderSpy).not.toHaveBeenCalled();
-        expect(defineRecordingSpy).not.toHaveBeenCalled();
-      });
-
-      it.skip('loads fixture if it exists, but contains no recordings', async () => {
+      it('loads fixture if it exists, but contains no recordings', async () => {
         const loadRecordingSpy = mocked(loadRecording);
         const disableNetConnectSpy = jest.spyOn(nock, 'disableNetConnect');
         const enableNetConnectSpy = jest.spyOn(nock, 'enableNetConnect');
@@ -674,7 +260,7 @@ describe('SuperfaceTest', () => {
 
         expect(loadRecordingSpy).toHaveBeenCalledTimes(1);
         expect(loadRecordingSpy).toHaveBeenCalledWith(
-          ...prepareLoadRecordingParameters()
+          prepareLoadRecordingParameters()
         );
         expect(restoreSpy).toHaveBeenCalledTimes(1);
         expect(pendingMocks()).toEqual([]);
@@ -684,10 +270,6 @@ describe('SuperfaceTest', () => {
     });
 
     describe('when performing', () => {
-      beforeEach(() => {
-        superfaceTest = new SuperfaceTest(testPayload);
-      });
-
       it('returns error from perform', async () => {
         mocked(prepareSuperface).mockResolvedValue(
           mockSuperface({
@@ -722,6 +304,37 @@ describe('SuperfaceTest', () => {
             value: 'result',
           })
         );
+      });
+    });
+
+    describe('when updating', () => {
+      let env: string | undefined;
+
+      beforeAll(() => {
+        env = process.env.UPDATE_TRAFFIC;
+
+        process.env.UPDATE_TRAFFIC = 'true';
+      });
+
+      afterAll(() => {
+        process.env.UPDATE_TRAFFIC = env;
+      });
+
+      it('merges new recordings with current ones', async () => {
+        const canUpdateTrafficSpy = mocked(canUpdateTraffic).mockResolvedValue(true);
+        const updateTrafficSpy = mocked(updateTraffic);
+
+        mocked(prepareSuperface).mockResolvedValue(mockSuperface());
+        mocked(matchWildCard).mockReturnValueOnce(true);
+        mocked(startRecording);
+        mocked(endRecording);
+
+        await superfaceTest.run({ input: defaultInput });
+
+        expect(canUpdateTrafficSpy).toHaveBeenCalledTimes(1);
+        expect(canUpdateTrafficSpy).toHaveBeenCalledWith(recordingsConfig.path);
+        expect(updateTrafficSpy).toHaveBeenCalledTimes(1);
+        expect(updateTrafficSpy).toHaveBeenCalledWith(recordingsConfig.path);
       });
     });
   });

--- a/src/superface-test.test.ts
+++ b/src/superface-test.test.ts
@@ -110,13 +110,6 @@ describe('SuperfaceTest', () => {
         await superfaceTest.run({ input: defaultInput });
 
         expect(recorderSpy).toHaveBeenCalledTimes(1);
-        expect(recorderSpy).toHaveBeenCalledWith({
-          dont_print: true,
-          output_objects: true,
-          use_separator: false,
-          enable_reqheaders_recording: false,
-        });
-
         expect(playSpy).toHaveBeenCalledTimes(1);
         expect(endRecSpy).toHaveBeenCalledTimes(1);
 
@@ -151,12 +144,6 @@ describe('SuperfaceTest', () => {
         await superfaceTest.run({ input: defaultInput });
 
         expect(recorderSpy).toHaveBeenCalledTimes(1);
-        expect(recorderSpy).toHaveBeenCalledWith({
-          dont_print: true,
-          output_objects: true,
-          use_separator: false,
-          enable_reqheaders_recording: false,
-        });
 
         expect(writeRecordingsSpy).toHaveBeenCalledWith(
           expect.stringMatching(DEFAULT_RECORDING_PATH),

--- a/src/superface-test.test.ts
+++ b/src/superface-test.test.ts
@@ -29,25 +29,18 @@ import {
 
 jest.mock('./superface/config');
 
-jest.mock('./common/io', () => ({
-  readFileQuiet: jest.fn(),
-  exists: jest.fn(),
-}));
-
 jest.mock('./common/format', () => ({
   ...jest.requireActual('./common/format'),
   matchWildCard: jest.fn(),
 }));
 
 jest.mock('./nock/recorder', () => ({
-  ...jest.requireActual('./nock/recorder'),
   startRecording: jest.fn(),
   endRecording: jest.fn(),
   loadRecording: jest.fn(),
 }));
 
 jest.mock('./nock/recorder.utils', () => ({
-  ...jest.requireActual('./nock/recorder.utils'),
   canUpdateTraffic: jest.fn(),
   updateTraffic: jest.fn(),
 }));

--- a/src/superface-test.ts
+++ b/src/superface-test.ts
@@ -78,7 +78,7 @@ export class SuperfaceTest {
       sf.useCaseName
     );
     const recordingsPath = this.setupRecordingPath(
-      recordingsKey,
+      sf.profileId,
       sf.providerName
     );
 
@@ -217,10 +217,7 @@ export class SuperfaceTest {
    * It also tries to look for current test file from test instance to save recordings
    * next to test files.
    */
-  private setupRecordingPath(
-    recordingsKey: string,
-    providerName: string
-  ): string {
+  private setupRecordingPath(profileId: string, providerName: string): string {
     const { path, fixture } = this.nockConfig ?? {};
     const fixtureName = `${providerName}.${fixture ?? 'recording'}`;
     const testFilePath = this.getTestFilePath();
@@ -228,7 +225,7 @@ export class SuperfaceTest {
     if (testFilePath === undefined) {
       return joinPath(
         path ?? joinPath(process.cwd(), 'recordings'),
-        recordingsKey,
+        profileId,
         fixtureName
       );
     } else {

--- a/src/superface-test.ts
+++ b/src/superface-test.ts
@@ -219,7 +219,7 @@ export class SuperfaceTest {
 
   /**
    * Sets up path to recording, depends on current Superface configuration and test case input.
-   * It also tries to look for current test file from test instance to save recordings 
+   * It also tries to look for current test file from test instance to save recordings
    * next to test files.
    */
   private setupRecordingPath(

--- a/src/superface-test.ts
+++ b/src/superface-test.ts
@@ -7,7 +7,13 @@ import { UnexpectedError } from './common/errors';
 import { getFixtureName, matchWildCard } from './common/format';
 import { IGenerator } from './generate-hash';
 import { MatchImpact } from './nock/analyzer';
-import { endRecording, loadRecording, startRecording } from './nock/recorder';
+import {
+  canUpdateTraffic,
+  endRecording,
+  loadRecording,
+  startRecording,
+  updateTraffic,
+} from './nock/recorder';
 import { RecordingType } from './nock/recording.interfaces';
 import { report, saveReport } from './reporter';
 import { prepareSuperface } from './superface/config';
@@ -82,11 +88,17 @@ export class SuperfaceTest {
     );
 
     debugSetup('Prepared path to recording:', recordingsPath);
+    debugSetup(
+      'Current recordings located at:',
+      `${recordingsKey}.${recordingsHash}`
+    );
 
-    // Replace currently supported traffic with new (with changes)
-    // if (await canUpdateTraffic(recordingsPath)) {
-    //   await updateTraffic(recordingsPath);
-    // }
+    // Merge currently supported traffic with new (with changes)
+    if (await canUpdateTraffic(recordingsPath)) {
+      debug('Updating current recordings file with new recordings file.');
+
+      await updateTraffic(recordingsPath);
+    }
 
     // Parse env variable and check if test should be recorded
     const record = matchWildCard(

--- a/src/superface-test.ts
+++ b/src/superface-test.ts
@@ -7,13 +7,8 @@ import { UnexpectedError } from './common/errors';
 import { getFixtureName, matchWildCard } from './common/format';
 import { IGenerator } from './generate-hash';
 import { MatchImpact } from './nock/analyzer';
-import {
-  canUpdateTraffic,
-  endRecording,
-  loadRecording,
-  startRecording,
-  updateTraffic,
-} from './nock/recorder';
+import { endRecording, loadRecording, startRecording } from './nock/recorder';
+import { canUpdateTraffic, updateTraffic } from './nock/recorder.utils';
 import { RecordingType } from './nock/recording.interfaces';
 import { report, saveReport } from './reporter';
 import { prepareSuperface } from './superface/config';
@@ -156,13 +151,15 @@ export class SuperfaceTest {
           recordingsType,
           recordingsHash,
           recordingsKey,
-          processRecordings,
           inputVariables,
           config: {
             boundProfileProvider: sf.boundProfileProvider,
             providerName: sf.providerName,
           },
-          beforeRecordingSave: options?.beforeRecordingSave,
+          options: {
+            processRecordings,
+            beforeRecordingSave: options?.beforeRecordingSave,
+          },
         });
       } else {
         restoreRecordings();

--- a/src/superface-test.ts
+++ b/src/superface-test.ts
@@ -104,21 +104,7 @@ export class SuperfaceTest {
     );
     const processRecordings = options?.processRecordings ?? true;
     const inputVariables = searchValues(testCase.input, options?.hideInput);
-    let recordingsType: RecordingType;
-
-    if (options?.prepare && options?.teardown) {
-      throw new UnexpectedError(
-        'Use just one of following parameters, either `prepare` or `teardown`'
-      );
-    }
-
-    if (options?.prepare) {
-      recordingsType = RecordingType.PREPARE;
-    } else if (options?.teardown) {
-      recordingsType = RecordingType.TEARDOWN;
-    } else {
-      recordingsType = RecordingType.MAIN;
-    }
+    const recordingsType = options?.recordingType ?? RecordingType.MAIN;
 
     if (record) {
       await startRecording(this.nockConfig?.enableReqheadersRecording);

--- a/src/superface-test.utils.test.ts
+++ b/src/superface-test.utils.test.ts
@@ -11,7 +11,7 @@ import {
 import {
   assertsDefinitionsAreNotStrings,
   checkSensitiveInformation,
-  getGenerator,
+  parseTestInstance,
 } from './superface-test.utils';
 
 describe('SuperfaceTest Utils', () => {
@@ -92,19 +92,35 @@ describe('SuperfaceTest Utils', () => {
     });
   });
 
-  describe('getGenerator', () => {
+  describe('parseTestInstance', () => {
     describe('when specified testInstance is jest expect instance', () => {
       it('returns JestGenerateHash instance', () => {
         const mockExpect = ((): void => {
-          console.log('simulating expect');
+          console.log('simulating jest expect');
         }) as any;
 
         mockExpect.getState = () => ({
           currentTestName: 'test name',
         });
 
-        expect(getGenerator(mockExpect)).toBeInstanceOf(JestGenerateHash);
+        const parsedTestInstance = parseTestInstance(mockExpect);
+
+        expect(parsedTestInstance.generator).toBeInstanceOf(JestGenerateHash);
       });
+
+      it('returns `getTestFilePath` function', () => {
+        const mockExpect = ((): void => {
+          console.log('simulating jest expect');
+        }) as any;
+
+        mockExpect.getState = () => ({
+          testPath: '/path/to/test/file.test.ts'
+        });
+
+        const parsedTestInstance = parseTestInstance(mockExpect);
+
+        expect(parsedTestInstance.getTestFilePath()).toBe('/path/to/test/file.test.ts')
+      })
     });
 
     describe('when specified testInstance is mocha instance', () => {
@@ -119,7 +135,11 @@ describe('SuperfaceTest Utils', () => {
             },
           };
 
-          expect(getGenerator(mockMocha)).toBeInstanceOf(MochaGenerateHash);
+          const parsedTestInstance = parseTestInstance(mockMocha);
+
+          expect(parsedTestInstance.generator).toBeInstanceOf(
+            MochaGenerateHash
+          );
         });
       });
 
@@ -132,8 +152,21 @@ describe('SuperfaceTest Utils', () => {
             },
           };
 
-          expect(getGenerator(mockMocha)).toBeInstanceOf(MochaGenerateHash);
+          const parsedTestInstance = parseTestInstance(mockMocha);
+
+          expect(parsedTestInstance.generator).toBeInstanceOf(
+            MochaGenerateHash
+          );
         });
+
+        // TODO: extend parsing of mocha to return path to test file
+        it('returns `getTestFilePath` function', () => {
+          const mockMocha = {}
+  
+          const parsedTestInstance = parseTestInstance(mockMocha);
+  
+          expect(parsedTestInstance.getTestFilePath()).toBeUndefined()
+        })
       });
     });
 
@@ -141,10 +174,20 @@ describe('SuperfaceTest Utils', () => {
       it('returns InputGenerateHash instance', () => {
         const mockTestInstance = undefined;
 
-        expect(getGenerator(mockTestInstance)).toBeInstanceOf(
+        const parsedTestInstance = parseTestInstance(mockTestInstance);
+
+        expect(parsedTestInstance.generator).toBeInstanceOf(
           InputGenerateHash
         );
       });
+
+      it('returns `getTestFilePath` function', () => {
+        const mockTestInstance = undefined
+
+        const parsedTestInstance = parseTestInstance(mockTestInstance);
+
+        expect(parsedTestInstance.getTestFilePath()).toBeUndefined()
+      })
     });
   });
 });

--- a/src/superface-test.utils.test.ts
+++ b/src/superface-test.utils.test.ts
@@ -114,13 +114,15 @@ describe('SuperfaceTest Utils', () => {
         }) as any;
 
         mockExpect.getState = () => ({
-          testPath: '/path/to/test/file.test.ts'
+          testPath: '/path/to/test/file.test.ts',
         });
 
         const parsedTestInstance = parseTestInstance(mockExpect);
 
-        expect(parsedTestInstance.getTestFilePath()).toBe('/path/to/test/file.test.ts')
-      })
+        expect(parsedTestInstance.getTestFilePath()).toBe(
+          '/path/to/test/file.test.ts'
+        );
+      });
     });
 
     describe('when specified testInstance is mocha instance', () => {
@@ -161,12 +163,12 @@ describe('SuperfaceTest Utils', () => {
 
         // TODO: extend parsing of mocha to return path to test file
         it('returns `getTestFilePath` function', () => {
-          const mockMocha = {}
-  
+          const mockMocha = {};
+
           const parsedTestInstance = parseTestInstance(mockMocha);
-  
-          expect(parsedTestInstance.getTestFilePath()).toBeUndefined()
-        })
+
+          expect(parsedTestInstance.getTestFilePath()).toBeUndefined();
+        });
       });
     });
 
@@ -176,18 +178,16 @@ describe('SuperfaceTest Utils', () => {
 
         const parsedTestInstance = parseTestInstance(mockTestInstance);
 
-        expect(parsedTestInstance.generator).toBeInstanceOf(
-          InputGenerateHash
-        );
+        expect(parsedTestInstance.generator).toBeInstanceOf(InputGenerateHash);
       });
 
       it('returns `getTestFilePath` function', () => {
-        const mockTestInstance = undefined
+        const mockTestInstance = undefined;
 
         const parsedTestInstance = parseTestInstance(mockTestInstance);
 
-        expect(parsedTestInstance.getTestFilePath()).toBeUndefined()
-      })
+        expect(parsedTestInstance.getTestFilePath()).toBeUndefined();
+      });
     });
   });
 });

--- a/src/superface-test.utils.ts
+++ b/src/superface-test.utils.ts
@@ -268,6 +268,13 @@ function hasProperty<K extends PropertyKey>(
   return !!obj && propKey in obj;
 }
 
+const getProperty: <K extends PropertyKey>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  obj: any,
+  propKey: K
+) => unknown = (obj, propKey) =>
+  hasProperty(obj, propKey) ? obj[propKey] : undefined;
+
 function isFunction<R extends unknown>(
   value: unknown,
   returnType?: R
@@ -281,12 +288,15 @@ function isFunction<R extends unknown>(
 
 /**
  * Checks for structural typing of specified `testInstance` and returns
- * corresponding instance of hash generator
+ * corresponding instance of hash generator and function to get current path.
  *
  * It checks for jest's `expect` instance and mocha's `this` instance,
  * otherwise it generates hash according to specified `testName` or `input` in test run
  */
-export function getGenerator(testInstance: unknown): IGenerator {
+export function parseTestInstance(testInstance: unknown): {
+  generator: IGenerator;
+  getTestFilePath: () => string | undefined;
+} {
   // jest instance of `expect` contains function `getState()` which should contain `currentTestName`
   if (testInstance && isFunction(testInstance)) {
     if (
@@ -294,9 +304,21 @@ export function getGenerator(testInstance: unknown): IGenerator {
       isFunction(testInstance.getState)
     ) {
       const state = testInstance.getState();
+      const generator = new JestGenerateHash(
+        getProperty(state, 'currentTestName')
+      );
+
+      const getTestFilePath = () => {
+        const testPath = getProperty(state, 'testPath');
+
+        return typeof testPath === 'string' ? testPath : undefined;
+      };
 
       if (state) {
-        return new JestGenerateHash(state as { currentTestName?: unknown });
+        return {
+          generator,
+          getTestFilePath,
+        };
       }
     }
   }
@@ -317,7 +339,10 @@ export function getGenerator(testInstance: unknown): IGenerator {
             const value = testInstance.currentTest.fullTitle();
 
             if (typeof value === 'string') {
-              return new MochaGenerateHash(value);
+              return {
+                generator: new MochaGenerateHash(value),
+                getTestFilePath: () => undefined,
+              };
             }
           }
         }
@@ -332,14 +357,20 @@ export function getGenerator(testInstance: unknown): IGenerator {
           const value = testInstance.test.fullTitle();
 
           if (typeof value === 'string') {
-            return new MochaGenerateHash(value);
+            return {
+              generator: new MochaGenerateHash(value),
+              getTestFilePath: () => undefined,
+            };
           }
         }
       }
     }
   }
 
-  return new InputGenerateHash();
+  return {
+    generator: new InputGenerateHash(),
+    getTestFilePath: () => undefined,
+  };
 }
 
 export function parseBooleanEnv(variable: string | undefined): boolean {

--- a/src/superface-test.utils.ts
+++ b/src/superface-test.utils.ts
@@ -305,7 +305,7 @@ export function parseTestInstance(testInstance: unknown): {
     ) {
       const state = testInstance.getState();
       const generator = new JestGenerateHash(
-        getProperty(state, 'currentTestName')
+        state as { currentTestName?: unknown }
       );
 
       const getTestFilePath = () => {

--- a/src/superface/config/prepare-files.test.ts
+++ b/src/superface/config/prepare-files.test.ts
@@ -17,7 +17,6 @@ const testPayload: SuperfaceTestConfig = {
 };
 
 jest.mock('./prepare-super-json', () => ({
-  ...jest.requireActual('./prepare-super-json'),
   getSuperJson: jest.fn(),
 }));
 
@@ -31,6 +30,10 @@ jest.mock('./prepare-provider-json', () => ({
 }));
 
 describe('Prepare files module', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   describe('prepareFiles', () => {
     it('fails when no profile is specified', async () => {
       mocked(getSuperJson).mockResolvedValue(mockSuperJson());

--- a/src/superface/config/prepare-superface.test.ts
+++ b/src/superface/config/prepare-superface.test.ts
@@ -19,6 +19,10 @@ jest.mock('./create-bound-profile-provider', () => ({
 }));
 
 describe('prepare superface module', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   describe('prepareSuperface', () => {
     it('fails when no useCase is specified', async () => {
       await expect(prepareSuperface({})).rejects.toThrowError(


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Refactors testing approach for saving recordings:
- save recordings next to test files if jest test instance is specified
- adds new parameter for specifying whether `prepare`, `teardown` or `main`
- group recordings to one file under structure `TestRecordings`
  - grouped by key `<profile>/<provider>/<usecase>`
  - and also by hash
- modify `JestGenerator` to expect primitive parameter
- modify `getGenerator` function and renamed it to `parseTestInstance`
  - returns also function to get path to current test file
  - currently only jest supported
- modify `matchTraffic` function to only run `Matcher` and return impact
- modify `TestRecordings` interface to contain also keys for `<profile>/<provider>/<usecase>`
- refactors `recorder` module
  - split code in multiple files and functions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Station recordings mess

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
