### PR TITLE
Pass sandbox to bound profile provider instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `@superfaceai/one-sdk` peer dependency from `^2.3` to `^2.4`
 
 ## [4.0.0] - 2023-02-08
 ### Changed

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepush": "yarn build && yarn test && yarn lint && yarn format"
   },
   "devDependencies": {
-    "@superfaceai/one-sdk": "^2.3.0",
+    "@superfaceai/one-sdk": "^2.4.0",
     "@superfaceai/parser": "^2.1.0",
     "@types/debug": "^4.1.7",
     "@types/jest": "^27.0.1",
@@ -51,7 +51,7 @@
     "nock": "^13.1.3"
   },
   "peerDependencies": {
-    "@superfaceai/one-sdk": "^2.3.0",
+    "@superfaceai/one-sdk": "^2.4.0",
     "@superfaceai/parser": "^2.1.0"
   }
 }

--- a/src/superface/mock/profile.ts
+++ b/src/superface/mock/profile.ts
@@ -12,6 +12,7 @@ import {
 import { mockProfileAST } from './ast';
 import { mockNodeFetch } from './fetch-instance';
 import { mockFileSystem } from './file-system';
+import { mockNodeSandbox } from './sandbox-instance';
 import { MockTimers } from './timers';
 
 const crypto = new NodeCrypto();
@@ -28,11 +29,13 @@ export function createProfile(options?: {
   }>();
   const fileSystem = mockFileSystem();
   const config = new Config(fileSystem);
+  const fetch = mockNodeFetch();
   const ast = mockProfileAST;
   const configuration = new ProfileConfiguration(
     options?.name ?? 'profile',
     '1.0.0'
   );
+  const sandbox = mockNodeSandbox();
 
   return new Profile(
     configuration,
@@ -40,10 +43,11 @@ export function createProfile(options?: {
     events,
     options?.superJson ?? undefined,
     config,
+    sandbox,
     timers,
     fileSystem,
     cache,
     crypto,
-    mockNodeFetch()
+    fetch,
   );
 }

--- a/src/superface/mock/sandbox-instance.ts
+++ b/src/superface/mock/sandbox-instance.ts
@@ -1,0 +1,12 @@
+import { NodeSandbox } from "@superfaceai/one-sdk";
+
+export const mockEvalScript = jest.fn();
+
+export const mockNodeSandbox = jest.fn<
+  NodeSandbox,
+  Parameters<() => NodeSandbox>
+>(
+  () => ({
+    evalScript: mockEvalScript
+  } as unknown as NodeSandbox));
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,10 +566,10 @@
     ajv "^8.8.2"
     ajv-formats "^2.1.1"
 
-"@superfaceai/one-sdk@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-2.3.0.tgz#7de9de084f8e69dc7fefe0a9b1e7d6abb3a69be7"
-  integrity sha512-6B2EdxE//vkri9ZBv6f8fHMoItCDoCO7XqbNBqpcYAsm3wj+8B7vC7eWRhN1+z6YPww1VzFLFmorF9UMc7jRdg==
+"@superfaceai/one-sdk@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-2.4.0.tgz#66e4d8dbc5c3eceab3812b47cd6e53efceab0bbb"
+  integrity sha512-x9kXcOiXoVTeiUHixSDJ2m1BDhVZj/AV1eVh0EFB38+jTz3N2T9MlW2xkFoy8oMkoMzQEeGWauwDGuDBbw0vCw==
   dependencies:
     "@superfaceai/ast" "1.3.0"
     abort-controller "^3.0.0"


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

updates OneSDK and properly instantiates BoundProfileProvider.

Requires [OneSDK 2.4.0 final release](https://github.com/superfaceai/one-sdk-js/releases/tag/untagged-c4ca6e02c843aef74331).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We can use latest OneSDK with testing library

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. If you are changing **code related to user secrets** you need to really make sure that [security documentation](SECURITY.md) is correct.
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
